### PR TITLE
134 password forms

### DIFF
--- a/apps/frontend/src/app/components/NewPasswordForm.tsx
+++ b/apps/frontend/src/app/components/NewPasswordForm.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import React from 'react';
+import TextInputField from './TextInputField';
+import { Button } from '@chakra-ui/react';
+
+export default function NewPasswordForm() {
+    return (
+        <div className="flex flex-col items-center text-center w-80">
+            <h1 className="![font-family:var(--font-heading)] !text-[36px] !font-semibold !mb-6">Reset Password</h1>
+            <div className="flex flex-col gap-4 w-full !mb-10">
+                <TextInputField label="New Password *" placeholder="Enter new password" errorMessage="Password is not valid"/>
+                <TextInputField label="Confirm Password *" placeholder="Retype password" errorMessage="Password does not match"/>
+            </div>
+            {/* TODO: form validation*/}
+            <Button className="![font-family:var(--font-body)] !rounded !bg-core-green !text-core-white w-full !px-4 !py-1.5 !mb-10">
+                Reset Password
+            </Button>
+        </div>
+    );
+}

--- a/apps/frontend/src/app/components/ResetPasswordConfirmation.tsx
+++ b/apps/frontend/src/app/components/ResetPasswordConfirmation.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import React from 'react';
+import { Button } from '@chakra-ui/react';
+import { useRouter } from 'next/navigation';
+
+
+export default function ResetPasswordConfirmation() {
+    const router = useRouter();
+
+    return (
+        <div className="flex flex-col items-center text-center w-90">
+            <div className="flex flex-col items-start gap-6">
+                <h1 className="![font-family:var(--font-heading)] !text-[36px] !font-semibold">Password Changed</h1>
+                <h5 className="![font-family:var(--font-body)] !text-[16px] !font-bold text-center !text-core-black !mb-6">Your password has been successfully changed!</h5>
+            </div>
+            {/*TODO: figure out how to connect the button to login page */}
+            <Button className="![font-family:var(--font-body)] !rounded !bg-core-green !text-core-white w-full !px-4 !py-1.5 !mb-10"
+                    onClick={() => router.push('/login')}>
+                Back to login
+            </Button>
+        </div>
+    );
+}

--- a/apps/frontend/src/app/login/page.tsx
+++ b/apps/frontend/src/app/login/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import TextInputField from './TextInputField';
+import TextInputField from '../components/TextInputField';
 import Link from 'next/link';
 import { Button } from '@chakra-ui/react';
 

--- a/apps/frontend/test/components/LoginPage.test.tsx
+++ b/apps/frontend/test/components/LoginPage.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '../utils';
-import LoginPage from '@/app/components/LoginPage';
+import LoginPage from '@/app/login/page';
 
 
 describe('Login Page Component', () => {

--- a/apps/frontend/test/components/NewPasswordForm.test.tsx
+++ b/apps/frontend/test/components/NewPasswordForm.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '../utils';
+import NewPasswordForm from '@/app/components/NewPasswordForm';
+
+
+describe('New Password Form Component', () => {
+    it('renders the form heading', () => {
+        render(<NewPasswordForm />);
+        expect(screen.getByText('Reset Password', { selector: 'h1' })).toBeInTheDocument();
+      });
+    
+    it('renders the 2 password input fields', () => {
+        render(<NewPasswordForm />);
+        expect(screen.getByPlaceholderText('Enter new password')).toBeInTheDocument();
+        expect(screen.getByPlaceholderText('Retype password')).toBeInTheDocument();
+    });
+
+    it('renders the reset password button', () => {
+        render(<NewPasswordForm />);
+        const button = screen.getByRole('button', { name: 'Reset Password' });
+        expect(button).toBeInTheDocument();
+    })
+});

--- a/apps/frontend/test/components/ResetPasswordConfirmation.test.tsx
+++ b/apps/frontend/test/components/ResetPasswordConfirmation.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '../utils';
+import ResetPasswordConfirmation from '@/app/components/ResetPasswordConfirmation';
+
+const mockPush = jest.fn();
+
+jest.mock('next/navigation', () => ({
+    useRouter: () => ({
+        push: mockPush,
+    }),
+}));
+
+
+describe('Reset Password Confirmation Page Component', () => {
+    
+    it('renders the page heading', () => {
+        render(<ResetPasswordConfirmation />);
+        expect(screen.getByText('Password Changed', { selector: 'h1' })).toBeInTheDocument();
+      });
+
+    it('renders the subheading', () => {
+        render(<ResetPasswordConfirmation />);
+        expect(screen.getByText('Your password has been successfully changed!', { selector: 'h5' })).toBeInTheDocument();
+    });
+
+    it('renders the back to login button', () => {
+        render(<ResetPasswordConfirmation />);
+        const button = screen.getByRole('button', { name: 'Back to login' });
+        expect(button).toBeInTheDocument();
+    })
+    
+    it('navigates to login page when back to login button is clicked', () => {
+        render(<ResetPasswordConfirmation />);
+        const button = screen.getByRole('button', { name: 'Back to login' });
+        button.click();
+        expect(mockPush).toHaveBeenCalledWith('/login');
+    });
+});


### PR DESCRIPTION
### ℹ️ Issue

Closes #134 
### 📝 Description

Created the pages for New Password form and Reset Password Confirmation. I also moved the login page into its own directory so we can access the route.

Briefly list the changes made to the code:
1. Added page files for new password form and reset password confirmation
2. Moved the pages into its own folder
3. Wrote tests to ensure it was working as expected and checked on local host to make sure it matched figma

### ✔️ Verification

What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves.

Provide screenshots of any new components, styling changes, or pages. 
<img width="1242" height="1384" alt="Screenshot 2026-04-06 172059" src="https://github.com/user-attachments/assets/ea8e68d9-d424-44ca-bd61-a5c25ccbd5a9" />
<img width="1245" height="1384" alt="Screenshot 2026-04-06 173718" src="https://github.com/user-attachments/assets/9564f803-eafb-4490-a1db-ee02fbca0b22" />
<img width="742" height="714" alt="Screenshot 2026-04-08 185313" src="https://github.com/user-attachments/assets/d4a9ce12-a598-4bed-954c-d1f82e8bc5bc" />
<img width="746" height="525" alt="image" src="https://github.com/user-attachments/assets/05d647ed-3317-423b-ae6e-1938430a50b9" />

### 🏕️ (Optional) Future Work / Notes

Did you notice anything ugly during the course of this ticket? Any bugs, design challenges, or unexpected behavior? Write it down so we can clean it up in a future ticket!
Nothing much, but the tree on the left side is still missing.