### PR TITLE
fix: explicitly exclude Deployment Summary from required PR checks

### DIFF
--- a/infrastructure/github/main.tf
+++ b/infrastructure/github/main.tf
@@ -38,7 +38,9 @@ resource "github_branch_protection" "main" {
   }
 
   required_status_checks {
-    strict   = true
+    strict = true
+    # "Deployment Summary" is intentionally excluded — it only runs on push to main
+    # (via lambda-deploy.yml) and should never be a required check on PRs.
     contexts = ["terraform-plan-summary", "lambda-tests", "frontend-ci"]
   }
 


### PR DESCRIPTION
removing "Deployment Summary" from the contexts list in terraform is to make it optional. 