### PR TITLE
expose project stats endpoint

### DIFF
--- a/apps/backend/lambdas/projects/README.md
+++ b/apps/backend/lambdas/projects/README.md
@@ -9,6 +9,7 @@ Lambda for managing projects.
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | /health | Health check |
+| GET | /dashboard |  |
 | GET | /projects/{id}/members |  |
 | GET | /projects |  |
 | GET | /projects/{id}/donors |  |

--- a/apps/backend/lambdas/projects/handler.ts
+++ b/apps/backend/lambdas/projects/handler.ts
@@ -1,6 +1,7 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import db from './db';
 import { ProjectValidationUtils } from './validation-utils';
+import { authenticateRequest } from './auth';
 
 export const handler = async (event: any): Promise<APIGatewayProxyResult> => {
   try {
@@ -199,6 +200,110 @@ export const handler = async (event: any): Promise<APIGatewayProxyResult> => {
       } catch (err) {
         console.error('Database error:', err);
         return json(500, { message: 'Failed to fetch expenditures', error: err instanceof Error ? err.message : 'Unknown error' });
+      }
+    }
+
+    // GET /dashboard
+    if ((normalizedPath === '/dashboard' || normalizedPath.endsWith('/dashboard')) && method === 'GET') {
+      const authHeader = event.headers?.Authorization || event.headers?.authorization;
+      const { user, error } = await authenticateRequest(authHeader);
+      if (!user) {
+        return json(401, { message: error || 'Authentication required' });
+      }
+      if (!user.isAdmin) {
+        return json(403, { message: 'Admin access required' });
+      }
+
+      try {
+        const [
+          totalSpentRow,
+          totalProjectsRow,
+          topCategoryRow,
+          projectRows,
+          spentByProject,
+          staffByProject,
+          monthRows,
+        ] = await Promise.all([
+          db.selectFrom('branch.expenditures')
+            .select(db.fn.sum('amount').as('total'))
+            .executeTakeFirst(),
+          db.selectFrom('branch.projects')
+            .select(db.fn.count('project_id').as('count'))
+            .executeTakeFirst(),
+          db.selectFrom('branch.expenditures')
+            .select(['category', db.fn.sum('amount').as('total')])
+            .where('category', 'is not', null)
+            .groupBy('category')
+            .orderBy(db.fn.sum('amount'), 'desc')
+            .limit(1)
+            .executeTakeFirst(),
+          db.selectFrom('branch.projects')
+            .selectAll()
+            .orderBy('project_id', 'asc')
+            .execute(),
+          db.selectFrom('branch.expenditures')
+            .select(['project_id', db.fn.sum('amount').as('total')])
+            .groupBy('project_id')
+            .execute(),
+          db.selectFrom('branch.project_memberships')
+            .select(['project_id', db.fn.count('user_id').as('count')])
+            .groupBy('project_id')
+            .execute(),
+          db.selectFrom('branch.expenditures')
+            .select(['spent_on', 'category', 'amount'])
+            .where('category', 'is not', null)
+            .execute(),
+        ]);
+
+        const totalSpent = Number(totalSpentRow?.total ?? 0);
+        const totalProjects = Number(totalProjectsRow?.count ?? 0);
+        const averageSpendPerProject = totalProjects > 0 ? totalSpent / totalProjects : 0;
+
+        const spentMap = new Map(spentByProject.map((r) => [r.project_id, Number(r.total)]));
+        const staffMap = new Map(staffByProject.map((r) => [r.project_id, Number(r.count)]));
+
+        const projects = projectRows.map((p) => {
+          const budget = p.total_budget !== null ? Number(p.total_budget) : null;
+          const spent = spentMap.get(p.project_id) ?? 0;
+          const spentPercentage = budget && budget > 0 ? (spent / budget) * 100 : 0;
+          return {
+            project_id: p.project_id,
+            name: p.name,
+            total_budget: budget,
+            currency: p.currency,
+            spent,
+            staff_count: staffMap.get(p.project_id) ?? 0,
+            spent_percentage: Number(spentPercentage.toFixed(2)),
+          };
+        });
+
+        const monthMap = new Map<string, { month: string; category: string; amount: number }>();
+        for (const row of monthRows) {
+          const d = new Date(row.spent_on as any);
+          const month = `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`;
+          const category = row.category as string;
+          const key = `${month}|${category}`;
+          const prev = monthMap.get(key);
+          if (prev) prev.amount += Number(row.amount);
+          else monthMap.set(key, { month, category, amount: Number(row.amount) });
+        }
+        const expensesByMonth = [...monthMap.values()].sort((a, b) => a.month.localeCompare(b.month));
+
+        return json(200, {
+          summary: {
+            topExpenseCategory: topCategoryRow
+              ? { category: topCategoryRow.category, amount: Number(topCategoryRow.total ?? 0) }
+              : null,
+            totalSpent,
+            totalProjects,
+            averageSpendPerProject: Number(averageSpendPerProject.toFixed(2)),
+          },
+          projects,
+          expensesByMonth,
+        });
+      } catch (err) {
+        console.error('Dashboard query failed:', err);
+        return json(500, { message: 'Failed to load dashboard' });
       }
     }
 

--- a/apps/backend/lambdas/projects/handler.ts
+++ b/apps/backend/lambdas/projects/handler.ts
@@ -24,6 +24,109 @@ export const handler = async (event: any): Promise<APIGatewayProxyResult> => {
 
     // >>> ROUTES-START (do not remove this marker)
     // CLI-generated routes will be inserted here
+    // GET /dashboard
+    if ((normalizedPath === '/dashboard' || normalizedPath.endsWith('/dashboard')) && method === 'GET') {
+      const authHeader = event.headers?.Authorization || event.headers?.authorization;
+      const { user, error } = await authenticateRequest(authHeader);
+      if (!user) {
+        return json(401, { message: error || 'Authentication required' });
+      }
+      if (!user.isAdmin) {
+        return json(403, { message: 'Admin access required' });
+      }
+
+      try {
+        const [
+          totalSpentRow,
+          totalProjectsRow,
+          topCategoryRow,
+          projectRows,
+          spentByProject,
+          staffByProject,
+          monthRows,
+        ] = await Promise.all([
+          db.selectFrom('branch.expenditures')
+            .select(db.fn.sum('amount').as('total'))
+            .executeTakeFirst(),
+          db.selectFrom('branch.projects')
+            .select(db.fn.count('project_id').as('count'))
+            .executeTakeFirst(),
+          db.selectFrom('branch.expenditures')
+            .select(['category', db.fn.sum('amount').as('total')])
+            .where('category', 'is not', null)
+            .groupBy('category')
+            .orderBy(db.fn.sum('amount'), 'desc')
+            .limit(1)
+            .executeTakeFirst(),
+          db.selectFrom('branch.projects')
+            .selectAll()
+            .orderBy('project_id', 'asc')
+            .execute(),
+          db.selectFrom('branch.expenditures')
+            .select(['project_id', db.fn.sum('amount').as('total')])
+            .groupBy('project_id')
+            .execute(),
+          db.selectFrom('branch.project_memberships')
+            .select(['project_id', db.fn.count('user_id').as('count')])
+            .groupBy('project_id')
+            .execute(),
+          db.selectFrom('branch.expenditures')
+            .select(['spent_on', 'category', 'amount'])
+            .where('category', 'is not', null)
+            .execute(),
+        ]);
+
+        const totalSpent = Number(totalSpentRow?.total ?? 0);
+        const totalProjects = Number(totalProjectsRow?.count ?? 0);
+        const averageSpendPerProject = totalProjects > 0 ? totalSpent / totalProjects : 0;
+
+        const spentMap = new Map(spentByProject.map((r) => [r.project_id, Number(r.total)]));
+        const staffMap = new Map(staffByProject.map((r) => [r.project_id, Number(r.count)]));
+
+        const projects = projectRows.map((p) => {
+          const budget = p.total_budget !== null ? Number(p.total_budget) : null;
+          const spent = spentMap.get(p.project_id) ?? 0;
+          const spentPercentage = budget && budget > 0 ? (spent / budget) * 100 : 0;
+          return {
+            project_id: p.project_id,
+            name: p.name,
+            total_budget: budget,
+            currency: p.currency,
+            spent,
+            staff_count: staffMap.get(p.project_id) ?? 0,
+            spent_percentage: Number(spentPercentage.toFixed(2)),
+          };
+        });
+
+        const monthMap = new Map<string, { month: string; category: string; amount: number }>();
+        for (const row of monthRows) {
+          const d = new Date(row.spent_on as any);
+          const month = `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`;
+          const category = row.category as string;
+          const key = `${month}|${category}`;
+          const prev = monthMap.get(key);
+          if (prev) prev.amount += Number(row.amount);
+          else monthMap.set(key, { month, category, amount: Number(row.amount) });
+        }
+        const expensesByMonth = [...monthMap.values()].sort((a, b) => a.month.localeCompare(b.month));
+
+        return json(200, {
+          summary: {
+            topExpenseCategory: topCategoryRow
+              ? { category: topCategoryRow.category, amount: Number(topCategoryRow.total ?? 0) }
+              : null,
+            totalSpent,
+            totalProjects,
+            averageSpendPerProject: Number(averageSpendPerProject.toFixed(2)),
+          },
+          projects,
+          expensesByMonth,
+        });
+      } catch (err) {
+        console.error('Dashboard query failed:', err);
+        return json(500, { message: 'Failed to load dashboard' });
+      }
+    }
     // GET /projects/{id}/members
     if (normalizedPath.startsWith('/projects/') && normalizedPath.split('/').length === 4 && normalizedPath.endsWith('/members') && method === 'GET') {
       const id = normalizedPath.split('/')[2];
@@ -200,110 +303,6 @@ export const handler = async (event: any): Promise<APIGatewayProxyResult> => {
       } catch (err) {
         console.error('Database error:', err);
         return json(500, { message: 'Failed to fetch expenditures', error: err instanceof Error ? err.message : 'Unknown error' });
-      }
-    }
-
-    // GET /dashboard
-    if ((normalizedPath === '/dashboard' || normalizedPath.endsWith('/dashboard')) && method === 'GET') {
-      const authHeader = event.headers?.Authorization || event.headers?.authorization;
-      const { user, error } = await authenticateRequest(authHeader);
-      if (!user) {
-        return json(401, { message: error || 'Authentication required' });
-      }
-      if (!user.isAdmin) {
-        return json(403, { message: 'Admin access required' });
-      }
-
-      try {
-        const [
-          totalSpentRow,
-          totalProjectsRow,
-          topCategoryRow,
-          projectRows,
-          spentByProject,
-          staffByProject,
-          monthRows,
-        ] = await Promise.all([
-          db.selectFrom('branch.expenditures')
-            .select(db.fn.sum('amount').as('total'))
-            .executeTakeFirst(),
-          db.selectFrom('branch.projects')
-            .select(db.fn.count('project_id').as('count'))
-            .executeTakeFirst(),
-          db.selectFrom('branch.expenditures')
-            .select(['category', db.fn.sum('amount').as('total')])
-            .where('category', 'is not', null)
-            .groupBy('category')
-            .orderBy(db.fn.sum('amount'), 'desc')
-            .limit(1)
-            .executeTakeFirst(),
-          db.selectFrom('branch.projects')
-            .selectAll()
-            .orderBy('project_id', 'asc')
-            .execute(),
-          db.selectFrom('branch.expenditures')
-            .select(['project_id', db.fn.sum('amount').as('total')])
-            .groupBy('project_id')
-            .execute(),
-          db.selectFrom('branch.project_memberships')
-            .select(['project_id', db.fn.count('user_id').as('count')])
-            .groupBy('project_id')
-            .execute(),
-          db.selectFrom('branch.expenditures')
-            .select(['spent_on', 'category', 'amount'])
-            .where('category', 'is not', null)
-            .execute(),
-        ]);
-
-        const totalSpent = Number(totalSpentRow?.total ?? 0);
-        const totalProjects = Number(totalProjectsRow?.count ?? 0);
-        const averageSpendPerProject = totalProjects > 0 ? totalSpent / totalProjects : 0;
-
-        const spentMap = new Map(spentByProject.map((r) => [r.project_id, Number(r.total)]));
-        const staffMap = new Map(staffByProject.map((r) => [r.project_id, Number(r.count)]));
-
-        const projects = projectRows.map((p) => {
-          const budget = p.total_budget !== null ? Number(p.total_budget) : null;
-          const spent = spentMap.get(p.project_id) ?? 0;
-          const spentPercentage = budget && budget > 0 ? (spent / budget) * 100 : 0;
-          return {
-            project_id: p.project_id,
-            name: p.name,
-            total_budget: budget,
-            currency: p.currency,
-            spent,
-            staff_count: staffMap.get(p.project_id) ?? 0,
-            spent_percentage: Number(spentPercentage.toFixed(2)),
-          };
-        });
-
-        const monthMap = new Map<string, { month: string; category: string; amount: number }>();
-        for (const row of monthRows) {
-          const d = new Date(row.spent_on as any);
-          const month = `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`;
-          const category = row.category as string;
-          const key = `${month}|${category}`;
-          const prev = monthMap.get(key);
-          if (prev) prev.amount += Number(row.amount);
-          else monthMap.set(key, { month, category, amount: Number(row.amount) });
-        }
-        const expensesByMonth = [...monthMap.values()].sort((a, b) => a.month.localeCompare(b.month));
-
-        return json(200, {
-          summary: {
-            topExpenseCategory: topCategoryRow
-              ? { category: topCategoryRow.category, amount: Number(topCategoryRow.total ?? 0) }
-              : null,
-            totalSpent,
-            totalProjects,
-            averageSpendPerProject: Number(averageSpendPerProject.toFixed(2)),
-          },
-          projects,
-          expensesByMonth,
-        });
-      } catch (err) {
-        console.error('Dashboard query failed:', err);
-        return json(500, { message: 'Failed to load dashboard' });
       }
     }
 

--- a/apps/backend/lambdas/projects/openapi.yaml
+++ b/apps/backend/lambdas/projects/openapi.yaml
@@ -97,6 +97,17 @@ paths:
                 items:
                   type: object
 
+  /dashboard:
+    get:
+      summary: GET /dashboard
+      responses:
+        '200':
+          description: OK
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+
   /projects/{id}/donors:
     get:
       summary: GET /projects/{id}/donors

--- a/apps/backend/lambdas/projects/test/dashboard.unit.test.ts
+++ b/apps/backend/lambdas/projects/test/dashboard.unit.test.ts
@@ -1,0 +1,190 @@
+import { describe, test, expect, beforeEach, jest } from '@jest/globals';
+
+jest.mock('../db');
+jest.mock('../auth');
+
+import { handler } from '../handler';
+import db from '../db';
+import { authenticateRequest } from '../auth';
+
+const mockDb = db as any;
+const mockAuthenticateRequest = authenticateRequest as jest.MockedFunction<typeof authenticateRequest>;
+
+function getEvent() {
+  return {
+    rawPath: '/dashboard',
+    requestContext: { http: { method: 'GET' } },
+    headers: { Authorization: 'Bearer fake-token' },
+    queryStringParameters: {},
+  };
+}
+
+const adminAuthResult = {
+  user: {
+    cognitoSub: 'admin-sub',
+    userId: 1,
+    email: 'ashley@branch.org',
+    isAdmin: true,
+  },
+};
+
+const nonAdminAuthResult = {
+  user: {
+    cognitoSub: 'staff-sub',
+    userId: 3,
+    email: 'nour@branch.org',
+    isAdmin: false,
+  },
+};
+
+function chain(value: any) {
+  const p: any = {};
+  for (const m of [
+    'select', 'selectAll', 'where', 'leftJoin', 'innerJoin',
+    'groupBy', 'orderBy', 'limit', 'offset',
+  ]) {
+    p[m] = jest.fn().mockReturnValue(p);
+  }
+  p.execute = jest.fn().mockResolvedValue(value as any);
+  p.executeTakeFirst = jest.fn().mockResolvedValue(value as any);
+  return p;
+}
+
+describe('GET /dashboard unit tests', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuthenticateRequest.mockResolvedValue(adminAuthResult as any);
+    mockDb.fn = {
+      sum: jest.fn().mockReturnValue({ as: jest.fn().mockReturnValue('sum') }),
+      count: jest.fn().mockReturnValue({ as: jest.fn().mockReturnValue('count') }),
+    };
+  });
+
+  describe('Authentication', () => {
+    test('401: unauthenticated request is rejected', async () => {
+      mockAuthenticateRequest.mockResolvedValue({ user: null as any, error: 'Missing or invalid Authorization header' });
+      const res = await handler(getEvent());
+      expect(res.statusCode).toBe(401);
+      expect(JSON.parse(res.body).message).toContain('Authorization');
+    });
+
+    test('403: authenticated non-admin is forbidden', async () => {
+      mockAuthenticateRequest.mockResolvedValue(nonAdminAuthResult as any);
+      const res = await handler(getEvent());
+      expect(res.statusCode).toBe(403);
+      expect(JSON.parse(res.body).message).toBe('Admin access required');
+    });
+  });
+
+  describe('Response shape', () => {
+    beforeEach(() => {
+      mockDb.selectFrom = jest.fn();
+      // 1) totalSpent
+      mockDb.selectFrom.mockReturnValueOnce(chain({ total: '18000.00' }));
+      // 2) totalProjects
+      mockDb.selectFrom.mockReturnValueOnce(chain({ count: '4' }));
+      // 3) topCategory
+      mockDb.selectFrom.mockReturnValueOnce(chain({ category: 'Travel', total: '6800.00' }));
+      // 4) projectRows
+      mockDb.selectFrom.mockReturnValueOnce(chain([
+        { project_id: 1, name: 'P1', total_budget: '500000.00', currency: 'USD' },
+        { project_id: 2, name: 'P2', total_budget: '300000.00', currency: 'USD' },
+        { project_id: 3, name: 'P3', total_budget: null, currency: 'USD' },
+      ]));
+      // 5) spentByProject
+      mockDb.selectFrom.mockReturnValueOnce(chain([
+        { project_id: 1, total: '9200.00' },
+        { project_id: 2, total: '4500.00' },
+        { project_id: 3, total: '4300.00' },
+      ]));
+      // 6) staffByProject
+      mockDb.selectFrom.mockReturnValueOnce(chain([
+        { project_id: 1, count: '2' },
+        { project_id: 2, count: '1' },
+      ]));
+      // 7) raw expenditure rows (handler buckets by YYYY-MM in JS)
+      mockDb.selectFrom.mockReturnValueOnce(chain([
+        { spent_on: new Date('2025-02-10'), category: 'Travel', amount: '5000.00' },
+        { spent_on: new Date('2025-03-22'), category: 'Travel Foreign', amount: '4200.00' },
+      ]));
+    });
+
+    test('200: summary aggregates returned values', async () => {
+      const res = await handler(getEvent());
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+
+      expect(body.summary.totalSpent).toBe(18000);
+      expect(body.summary.totalProjects).toBe(4);
+      expect(body.summary.averageSpendPerProject).toBe(4500);
+      expect(body.summary.topExpenseCategory).toEqual({ category: 'Travel', amount: 6800 });
+    });
+
+    test('200: projects breakdown joins spent and staff_count by project_id', async () => {
+      const res = await handler(getEvent());
+      const body = JSON.parse(res.body);
+      expect(body.projects).toHaveLength(3);
+      expect(body.projects[0]).toMatchObject({
+        project_id: 1,
+        name: 'P1',
+        total_budget: 500000,
+        spent: 9200,
+        staff_count: 2,
+      });
+      expect(body.projects[0].spent_percentage).toBeCloseTo(1.84, 2);
+
+      // project with no membership row -> staff_count 0
+      expect(body.projects[2].staff_count).toBe(0);
+      // project with null budget -> 0%
+      expect(body.projects[2].total_budget).toBeNull();
+      expect(body.projects[2].spent_percentage).toBe(0);
+    });
+
+    test('200: expensesByMonth buckets raw rows into YYYY-MM', async () => {
+      const res = await handler(getEvent());
+      const body = JSON.parse(res.body);
+      expect(body.expensesByMonth).toEqual([
+        { month: '2025-02', category: 'Travel', amount: 5000 },
+        { month: '2025-03', category: 'Travel Foreign', amount: 4200 },
+      ]);
+    });
+
+    test('200: response has CORS + JSON headers', async () => {
+      const res = await handler(getEvent());
+      expect(res.headers?.['Content-Type']).toBe('application/json');
+      expect(res.headers?.['Access-Control-Allow-Origin']).toBe('*');
+    });
+  });
+
+  describe('Edge cases', () => {
+    test('200: empty database returns zeros and null topExpenseCategory', async () => {
+      mockDb.selectFrom = jest.fn();
+      mockDb.selectFrom.mockReturnValueOnce(chain({ total: null }));
+      mockDb.selectFrom.mockReturnValueOnce(chain({ count: '0' }));
+      mockDb.selectFrom.mockReturnValueOnce(chain(undefined));
+      mockDb.selectFrom.mockReturnValueOnce(chain([]));
+      mockDb.selectFrom.mockReturnValueOnce(chain([]));
+      mockDb.selectFrom.mockReturnValueOnce(chain([]));
+      mockDb.selectFrom.mockReturnValueOnce(chain([]));
+
+      const res = await handler(getEvent());
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body.summary.totalSpent).toBe(0);
+      expect(body.summary.totalProjects).toBe(0);
+      expect(body.summary.averageSpendPerProject).toBe(0);
+      expect(body.summary.topExpenseCategory).toBeNull();
+      expect(body.projects).toEqual([]);
+      expect(body.expensesByMonth).toEqual([]);
+    });
+
+    test('500: db failure surfaces as 500', async () => {
+      mockDb.selectFrom = jest.fn().mockImplementation(() => {
+        throw new Error('boom');
+      });
+      const res = await handler(getEvent());
+      expect(res.statusCode).toBe(500);
+      expect(JSON.parse(res.body).message).toBe('Failed to load dashboard');
+    });
+  });
+});

--- a/apps/backend/lambdas/projects/test/projects.e2e.test.ts
+++ b/apps/backend/lambdas/projects/test/projects.e2e.test.ts
@@ -1,5 +1,33 @@
+import { jest } from '@jest/globals';
+import fs from 'fs';
+import path from 'path';
+import { Pool } from 'pg';
+
+jest.mock('../auth');
+
 import { handler } from '../handler';
 import db from '../db';
+import { authenticateRequest } from '../auth';
+
+const mockAuthenticateRequest = authenticateRequest as jest.MockedFunction<typeof authenticateRequest>;
+
+const adminAuthResult = {
+  user: {
+    cognitoSub: 'admin-sub',
+    userId: 1,
+    email: 'ashley@branch.org',
+    isAdmin: true,
+  },
+};
+
+const nonAdminAuthResult = {
+  user: {
+    cognitoSub: 'staff-sub',
+    userId: 3,
+    email: 'nour@branch.org',
+    isAdmin: false,
+  },
+};
 
 beforeAll(() => {
   process.env.DB_HOST = process.env.DB_HOST ?? 'localhost';
@@ -127,6 +155,114 @@ describe('GET /projects/{id}/expenditures (e2e)', () => {
         expect(current >= next).toBe(true);
       }
     }
+  });
+});
+
+describe('GET /dashboard (e2e)', () => {
+  const pool = new Pool({
+    host: 'localhost',
+    port: Number(5432),
+    user: 'branch_dev',
+    password: 'password',
+    database: 'branch_db',
+    ssl: false,
+  });
+
+  const seedSqlPath = path.resolve(__dirname, '../../../db/db_setup.sql');
+  const seedSql = fs.readFileSync(seedSqlPath, 'utf8');
+
+  function dashboardEvent() {
+    return {
+      rawPath: '/dashboard',
+      requestContext: { http: { method: 'GET' } },
+      headers: { Authorization: 'Bearer fake-token' },
+      queryStringParameters: {},
+    } as any;
+  }
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockAuthenticateRequest.mockResolvedValue(adminAuthResult as any);
+
+    const client = await pool.connect();
+    try {
+      await client.query(seedSql);
+    } finally {
+      client.release();
+    }
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  test('401: unauthenticated request rejected 🌞', async () => {
+    mockAuthenticateRequest.mockResolvedValue({ user: null as any, error: 'Missing or invalid Authorization header' });
+    const res = await handler(dashboardEvent());
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('403: non-admin is forbidden 🌞', async () => {
+    mockAuthenticateRequest.mockResolvedValue(nonAdminAuthResult as any);
+    const res = await handler(dashboardEvent());
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).message).toBe('Admin access required');
+  });
+
+  test('summary aggregates seed totals 🌞', async () => {
+    const res = await handler(dashboardEvent());
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+
+    expect(body.summary.totalProjects).toBe(4);
+    expect(body.summary.totalSpent).toBe(18000);
+    expect(body.summary.averageSpendPerProject).toBe(4500);
+  });
+
+  test('topExpenseCategory is highest-summed category 🌞', async () => {
+    const res = await handler(dashboardEvent());
+    const body = JSON.parse(res.body);
+    expect(body.summary.topExpenseCategory).not.toBeNull();
+    expect(body.summary.topExpenseCategory.category).toBe('Travel');
+    expect(body.summary.topExpenseCategory.amount).toBe(6800);
+  });
+
+  test('projects breakdown returns budget, spent and staff_count per project 🌞', async () => {
+    const res = await handler(dashboardEvent());
+    const body = JSON.parse(res.body);
+    expect(body.projects.length).toBe(4);
+
+    const p1 = body.projects.find((p: any) => p.project_id === 1);
+    expect(p1.name).toContain('Clinician Communication Study');
+    expect(p1.total_budget).toBe(500000);
+    expect(p1.spent).toBe(9200);
+    expect(p1.staff_count).toBe(2);
+    expect(p1.spent_percentage).toBeCloseTo(1.84, 2);
+  });
+
+  test('projects with no expenditures or members report zeros 🌞', async () => {
+    const res = await handler(dashboardEvent());
+    const body = JSON.parse(res.body);
+    const projB = body.projects.find((p: any) => p.name === 'Proj B');
+    expect(projB).toBeDefined();
+    expect(projB.spent).toBe(0);
+    expect(projB.staff_count).toBe(0);
+  });
+
+  test('expensesByMonth rows are chronological with numeric amounts 🌞', async () => {
+    const res = await handler(dashboardEvent());
+    const body = JSON.parse(res.body);
+    expect(Array.isArray(body.expensesByMonth)).toBe(true);
+    expect(body.expensesByMonth.length).toBeGreaterThan(0);
+
+    for (let i = 0; i < body.expensesByMonth.length - 1; i++) {
+      expect(body.expensesByMonth[i].month <= body.expensesByMonth[i + 1].month).toBe(true);
+    }
+
+    body.expensesByMonth.forEach((row: any) => {
+      expect(typeof row.month).toBe('string');
+      expect(typeof row.amount).toBe('number');
+    });
   });
 });
 


### PR DESCRIPTION
### ℹ️ Issue

Closes #201 

### 📝 Description

Added /dashboard endpoint in projects to expose the project stats for the admin dashboard and is locked down to only admins.

Briefly list the changes made to the code:
1. Added /dashboard to projects lambda to get and calculate the project stats for the admin dashboard
2. Added tests to validate endpoint


### ✔️ Verification

Added tests

### 🏕️ (Optional) Future Work / Notes

Did you notice anything ugly during the course of this ticket? Any bugs, design challenges, or unexpected behavior? Write it down so we can clean it up in a future ticket!
