### PR TITLE
216 - Add profile_image to the user model in database

### DIFF
--- a/apps/backend/db/db_setup.sql
+++ b/apps/backend/db/db_setup.sql
@@ -8,7 +8,8 @@ CREATE TABLE users (
     name VARCHAR(100) NOT NULL,
     email VARCHAR(150) UNIQUE NOT NULL,
     is_admin BOOLEAN DEFAULT FALSE,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    profile_image TEXT
 );
 
 CREATE TABLE projects (

--- a/apps/backend/lambdas/users/db-types.d.ts
+++ b/apps/backend/lambdas/users/db-types.d.ts
@@ -67,6 +67,7 @@ export interface BranchUsers {
   is_admin: Generated<boolean | null>;
   name: string;
   user_id: Generated<number>;
+  profile_image: string | null;
 }
 
 export interface DB {

--- a/apps/backend/lambdas/users/handler.ts
+++ b/apps/backend/lambdas/users/handler.ts
@@ -105,7 +105,8 @@ export const handler = async (event: any): Promise<APIGatewayProxyResult> => {
           userId: user.user_id,
           email: user.email, 
           name: user.name, 
-          isAdmin: user.is_admin 
+          isAdmin: user.is_admin,
+          profile_image: user.profile_image,
         } 
       });
     }
@@ -127,17 +128,18 @@ export const handler = async (event: any): Promise<APIGatewayProxyResult> => {
       let email = body.email as string;
       let name = body.name as string;
       let isAdmin = body.isAdmin as boolean;
+      let profileImage = body.profileImage as string | undefined;
 
       // update
       await db.updateTable('branch.users')
-               .set({ email, name, is_admin: isAdmin })
+               .set({ email, name, is_admin: isAdmin, profile_image: profileImage })
                .where('user_id', '=', Number(userId))
                .execute();
 
       // get updated user
       let updatedUser = await db.selectFrom("branch.users").where("user_id", "=", Number(userId)).selectAll().executeTakeFirst();
 
-      return json(200, { ok: true, route: 'PATCH /users/{userId}', pathParams: { userId }, body: { email: updatedUser!.email, name: updatedUser!.name, isAdmin: updatedUser!.is_admin } });
+      return json(200, { ok: true, route: 'PATCH /users/{userId}', pathParams: { userId }, body: { email: updatedUser!.email, name: updatedUser!.name, isAdmin: updatedUser!.is_admin, profileImage: updatedUser!.profile_image } });
     }
     
     // DELETE /users/{userId}
@@ -173,6 +175,7 @@ export const handler = async (event: any): Promise<APIGatewayProxyResult> => {
       if (!email || !name || typeof isAdmin !== 'boolean') {
         return json(400, { message: 'email, name, and isAdmin are required' });
       }
+      let profile_image = body.profileImage as string;
 
       // Check if user with this email already exists
       const existingUser = await db
@@ -189,7 +192,7 @@ export const handler = async (event: any): Promise<APIGatewayProxyResult> => {
       try {
         await db
           .insertInto('branch.users')
-          .values({ email, name, is_admin: isAdmin })
+          .values({ email, name, is_admin: isAdmin, profile_image })
           .execute();
       } catch (err) {
         console.error('Database insert error:', err);

--- a/apps/backend/lambdas/users/openapi.yaml
+++ b/apps/backend/lambdas/users/openapi.yaml
@@ -49,6 +49,8 @@ paths:
                   type: string
                 isAdmin:
                   type: boolean
+                profileImage:
+                  type: string
       responses:
         '201':
           description: Success
@@ -78,6 +80,8 @@ paths:
                   type: string
                 isAdmin:
                   type: boolean
+                profileImage:
+                  type: string
       responses:
         '200':
           description: OK

--- a/apps/backend/lambdas/users/test/users.test.ts
+++ b/apps/backend/lambdas/users/test/users.test.ts
@@ -162,6 +162,27 @@ test("patch user test 🌞", async () => {
   }
 });
 
+test("patch user profile_image test 🌞", async () => {
+  mockAdminAuth();
+
+  const patchEvent = createEvent({
+    method: 'PATCH',
+    path: '/1',
+    body: {
+      name: "Ashley Duggan",
+      email: "ashley@branch.org",
+      isAdmin: true,
+      profileImage: "https://s3.amazonaws.com/branch-avatars/ashley.png"
+    },
+  });
+
+  const res = await handler(patchEvent);
+  expect(res.statusCode).toBe(200);
+
+  const body = JSON.parse(res.body).body;
+  expect(body.profileImage).toBe("https://s3.amazonaws.com/branch-avatars/ashley.png");
+});
+
 
 test("patch user 404 test 🌞", async () => {
   mockAdminAuth();


### PR DESCRIPTION

### ℹ️ Issue

Closes #216 

### 📝 Description

Added the profile_image to the user table in the database

Briefly list the changes made to the code:
1. Added the new column in the db setup file
2. Changed the GET, POST, and PATCH endpoints in lambdas/users/handler.ts to include the new profile_image column
3. Wrote an E2E test and verified the endpoints work as expected

### ✔️ Verification

Tested through Swagger UI and ran jest tests. All jest tests passed and all Swagger UI tests returned 200 status code.

Jest tests:
<img width="541" height="145" alt="Screenshot 2026-06-01 222336" src="https://github.com/user-attachments/assets/e0ae19d6-0e0f-4ea7-8905-a6ecf46b0d79" />
POST endpoint:
<img width="2376" height="1258" alt="Screenshot 2026-06-01 223534" src="https://github.com/user-attachments/assets/0247dcb6-4a5a-4783-b8bb-48813f668ae8" />
PATCH endpoint:
<img width="2370" height="1229" alt="Screenshot 2026-06-01 223626" src="https://github.com/user-attachments/assets/1f018e56-a835-47e0-bfe0-ff914df4e5a3" />
GET endpoint:
<img width="2365" height="1103" alt="Screenshot 2026-06-01 223655" src="https://github.com/user-attachments/assets/a1be7f69-65b6-48d0-86d8-fd59c510f2a9" />
PATCH endpoint (no profile_image added):
<img width="2404" height="1355" alt="Screenshot 2026-06-01 225736" src="https://github.com/user-attachments/assets/070db076-d384-4b06-933b-a7bbe61698de" />


### 🏕️ (Optional) Future Work / Notes

Did you notice anything ugly during the course of this ticket? Any bugs, design challenges, or unexpected behavior? Write it down so we can clean it up in a future ticket!
