### PR TITLE
fix: Lambda Deploy artifact name (forward slash) + workflow_dispatch

### DIFF
--- a/.github/workflows/lambda-deploy.yml
+++ b/.github/workflows/lambda-deploy.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'apps/backend/lambdas/**'
       - 'shared/types/**'
+  workflow_dispatch:
 
 jobs:
   detect-changes:
@@ -74,11 +75,15 @@ jobs:
       - name: Package lambda
         working-directory: ${{ matrix.lambda }}
         run: npm run package
-      
+
+      - name: Compute artifact name
+        id: artifact
+        run: echo "name=lambda-$(basename ${{ matrix.lambda }})" >> $GITHUB_OUTPUT
+
       - name: Upload lambda artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.lambda }}
+          name: ${{ steps.artifact.outputs.name }}
           path: ${{ matrix.lambda }}/lambda.zip
           if-no-files-found: error
 
@@ -95,12 +100,16 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: us-east-2
     steps:
+      - name: Compute artifact name
+        id: artifact
+        run: echo "name=lambda-$(basename ${{ matrix.lambda }})" >> $GITHUB_OUTPUT
+
       - name: Download lambda artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ matrix.lambda }}
+          name: ${{ steps.artifact.outputs.name }}
           path: ${{ matrix.lambda }}
-      
+
       - name: Deploy lambda
         run: |
           LAMBDA_NAME=$(basename ${{ matrix.lambda }})


### PR DESCRIPTION
## Problem
`Lambda Deploy` on `main` has been failing on every push. Backend lambdas never deploy.

Root cause — `actions/upload-artifact@v4` rejects `/` in artifact names:
```
The artifact name is not valid: apps/backend/lambdas/donors. Contains the following character:  Forward slash /
```
The workflow used `name: ${{ matrix.lambda }}` (the full path), so every `build` matrix job failed at upload, and `deploy` (which `needs: build`) never ran.

## Fix
- Compute a slash-free artifact name `lambda-<basename>` in both `build` (upload) and `deploy` (download). `path:` still uses the full lambda path.
- Add `workflow_dispatch` to allow manual redeploys (push trigger only fires on `apps/backend/lambdas/**` / `shared/types/**` changes).

## Test
Merge to `main` then trigger via Actions → Lambda Deploy → Run workflow, or push a lambda change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)