### PR TITLE
fix: make Amplify frontend SSR deploy functional

### DIFF
--- a/infrastructure/aws/README.md
+++ b/infrastructure/aws/README.md
@@ -34,7 +34,9 @@ No modules.
 | [aws_cognito_user_pool.branch_user_pool](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/cognito_user_pool) | resource |
 | [aws_cognito_user_pool_client.branch_client](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/cognito_user_pool_client) | resource |
 | [aws_db_instance.branch_rds](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/db_instance) | resource |
+| [aws_iam_role.amplify_ssr](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/iam_role) | resource |
 | [aws_iam_role.lambda_role](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.amplify_ssr](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.lambda_basic](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_lambda_function.functions](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/lambda_function) | resource |
 | [aws_lambda_permission.api_gateway_permissions](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/lambda_permission) | resource |

--- a/infrastructure/aws/amplify.tf
+++ b/infrastructure/aws/amplify.tf
@@ -1,8 +1,28 @@
+# SSR (WEB_COMPUTE) apps require a service role so Amplify can provision the
+# compute backend and write its CloudWatch logs. Without it, SSR deploys fail.
+resource "aws_iam_role" "amplify_ssr" {
+  name = "branch-amplify-ssr-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "amplify.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "amplify_ssr" {
+  role       = aws_iam_role.amplify_ssr.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess-Amplify"
+}
+
 resource "aws_amplify_app" "frontend" {
-  name         = "branch-frontend"
-  repository   = "https://github.com/Code-4-Community/branch"
-  access_token = data.infisical_secrets.github_folder.secrets["branch-gh-admin"].value
-  platform     = "WEB_COMPUTE"
+  name                 = "branch-frontend"
+  repository           = "https://github.com/Code-4-Community/branch"
+  access_token         = data.infisical_secrets.github_folder.secrets["branch-gh-admin"].value
+  platform             = "WEB_COMPUTE"
+  iam_service_role_arn = aws_iam_role.amplify_ssr.arn
 
   build_spec = <<-EOT
     version: 1
@@ -25,7 +45,10 @@ resource "aws_amplify_app" "frontend" {
 
   environment_variables = {
     AMPLIFY_MONOREPO_APP_ROOT = "apps/frontend"
-    NEXT_PUBLIC_API_BASE_URL  = var.api_base_url
+    # Default the API base URL to the deployed API Gateway stage so the built
+    # frontend talks to the real backend instead of localhost. var.api_base_url
+    # still overrides when set (was previously "" -> apiFetch hit localhost).
+    NEXT_PUBLIC_API_BASE_URL = var.api_base_url != "" ? var.api_base_url : aws_api_gateway_stage.branch_stage.invoke_url
   }
 
   enable_branch_auto_deletion = true


### PR DESCRIPTION
## Why

The frontend deployment is broken for 2 reasons

1. No SSR service role which Amplify requires with our config
2. Public API base URL not set

- Add `branch-amplify-ssr-role` (trust `amplify.amazonaws.com`) + AWS-managed `AdministratorAccess-Amplify`; set `iam_service_role_arn` on the app.
- Default `NEXT_PUBLIC_API_BASE_URL` to the deployed API Gateway stage `invoke_url` (`var.api_base_url` still overrides when set).

## Verification

See terraform plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)