### PR TITLE
Fix for Failing Regen DB Types Workflow on Merges to Main

### DIFF
--- a/.github/workflows/regenerate-db-types.yaml
+++ b/.github/workflows/regenerate-db-types.yaml
@@ -229,10 +229,24 @@ jobs:
             fi
 
             git commit -m "$COMMIT_MESSAGE"
-            
-            git push origin HEAD:${{ github.head_ref || github.ref_name }}
+
+            TARGET_BRANCH="${{ github.head_ref }}"
+
+            if [ -z "$TARGET_BRANCH" ]; then
+              TARGET_BRANCH="chore/auto-regenerate-db-types-$(date +%Y%m%d%H%M%S)"
+              git push origin HEAD:$TARGET_BRANCH
+              gh pr create \
+                --title "chore: auto-regenerate database types from schema changes" \
+                --body "Automated PR to update \`shared/types/db-types.d.ts\` after schema changes merged to main." \
+                --base main \
+                --head $TARGET_BRANCH
+            else
+              git push origin HEAD:$TARGET_BRANCH
+            fi
 
             echo "Changes committed + pushed successfully"
+          env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
         - name: Comment on PR
           if: steps.git-check.outputs.changes == 'true' && github.event_name == 'pull_request'


### PR DESCRIPTION
### ℹ️ Issue

#226 was supposed to be closed in a previous PR, but this workflow is failing on merges to `main` because it tries to push commits to it when it's a protected branch. It is currently working for changes pushed within a PR though

### 📝 Description

1. The workflow runs after a merge to main (via workflow_run). At that point github.head_ref is empty, so there's no PR branch to push back to
2. Previously, the push used `github.head_ref || github.ref_name`. With `head_ref` empty, it fell back to `github.ref_name` which is main, blocked by branch protection
3. The fix checks if `github.head_ref` is set:                                                                                                                               
    - If yes (running on a PR) -> push back to the PR branch as before                                                                                                        
    - If no (running after a merge to main) -> create a new branch with a timestamped name like chore/auto-regenerate-db-types-20260630123456, push there, and open a PR against main automatically

### ✔️ Verification

Will update this PR once I verify this change using `act`

### 🏕️ (Optional) Future Work / Notes

Did you notice anything ugly during the course of this ticket? Any bugs, design challenges, or unexpected behavior? Write it down so we can clean it up in a future ticket!
