### PR TITLE
fix: unwedge terraform-apply on RDS engine version drift

### DIFF
--- a/infrastructure/aws/main.tf
+++ b/infrastructure/aws/main.tf
@@ -1,10 +1,15 @@
 resource "aws_db_instance" "branch_rds" {
-  allocated_storage   = 10
-  db_name             = "branch_rds"
-  engine              = "postgres"
-  engine_version      = "17.6"
-  instance_class      = "db.t3.micro"
-  username            = data.infisical_secrets.rds_folder.secrets["username"].value
-  password            = data.infisical_secrets.rds_folder.secrets["password"].value
-  skip_final_snapshot = true
+  allocated_storage = 10
+  db_name           = "branch_rds"
+  engine            = "postgres"
+  # Set to the live version (RDS auto-upgraded 17.6 -> 17.9). Disable auto minor
+  # upgrades so the version can't drift above what's pinned here — otherwise
+  # `terraform apply` tries to "downgrade" and AWS rejects it, failing the whole
+  # aws module. Version bumps are now intentional (edit this + apply).
+  engine_version             = "17.9"
+  auto_minor_version_upgrade = false
+  instance_class             = "db.t3.micro"
+  username                   = data.infisical_secrets.rds_folder.secrets["username"].value
+  password                   = data.infisical_secrets.rds_folder.secrets["password"].value
+  skip_final_snapshot        = true
 }


### PR DESCRIPTION
## Why

`terraform-apply` for the `aws` module has been **failing on every merge to main** (e.g. the #256 Amplify run):

```
Error: updating RDS DB Instance ... InvalidParameterCombination: Cannot upgrade postgres from 17.9 to 17.6
```

`main.tf` pinned `engine_version = "17.6"`, but RDS auto-applied a minor upgrade to **17.9** on the live instance. Terraform then plans a "downgrade" 17.9 → 17.6, AWS rejects it, and the **entire aws-module apply aborts**. That's why #256's Amplify changes (SSR `iam_service_role_arn`, `NEXT_PUBLIC_API_BASE_URL`) never landed — the apply died on RDS before reaching the Amplify update.

## What

- `engine_version = "17.9"` — match the live instance, stop the downgrade attempt.
- `auto_minor_version_upgrade = false` — keep the version from drifting above the pin again, so apply stays green. Version bumps become an intentional edit-then-apply (tradeoff: minor patches are no longer automatic).

## Effect

Once merged, `terraform-apply` should succeed and finally apply the pending Amplify SSR config from #256. The Amplify app (`dbcy90q4o31f7`) still shows the default "Welcome" placeholder — after this + that apply, a push to `main` should trigger the first real SSR build.

## Verification

- `terraform fmt` clean.
- Plan runs via `terraform-plan` on this PR — confirm it shows only the RDS in-place update (`engine_version` 17.6→17.9 metadata + `auto_minor_version_upgrade` false) and **no destroy**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)