### PR TITLE
fix: run db-types regeneration on PR instead of workflow_run chain

### DIFF
--- a/.github/workflows/regenerate-db-types.yaml
+++ b/.github/workflows/regenerate-db-types.yaml
@@ -4,9 +4,6 @@ on:
   pull_request:
     paths:
       - apps/backend/db/db_setup.sql
-  workflow_run:
-    workflows: ["Lambda README Generation"]
-    types: [completed]
   workflow_dispatch:
 
 
@@ -24,13 +21,13 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      github.event_name == 'pull_request'
     
     steps:
         - name: Checkout
           uses: actions/checkout@v4
           with:
-            ref: ${{ github.event.workflow_run.head_branch || github.ref }}
+            ref: ${{ github.head_ref || github.ref }}
             token: ${{ secrets.GITHUB_TOKEN }}
             fetch-depth: 0
         


### PR DESCRIPTION
## Problem

`regenerate-db-types.yaml` fails because it tries to `git push` to `main` (a protected branch).

Root cause is a broken `workflow_run` chain:

```
terraform-plan (PR/merge_group) ──workflow_run──▶ lambda-readme ──workflow_run──▶ regenerate-db-types
```

`workflow_run`-triggered workflows always execute in the **default-branch (main) context** — `github.ref_name` resolves to `main` regardless of which PR triggered the chain. Two compounding bugs:

1. The job `if` was gated to `workflow_dispatch || workflow_run.conclusion == 'success'`, so on a real `pull_request` event **the job was skipped entirely** — it only ran via the chain, in main context.
2. The push step `git push origin HEAD:${{ github.head_ref || github.ref_name }}` fell through to `github.ref_name` = `main` under `workflow_run` → push to protected `main` → **fails**.

## Fix

Run the regeneration directly on the PR that changes the schema:

- Remove the `workflow_run: ["Lambda README Generation"]` trigger.
- Change the job `if` to run on `pull_request` events.
- Check out `github.head_ref` so regenerated types commit back to the **PR branch**, never `main`.

Behavior (auto-commit types to the PR branch) and scope (path filter on `apps/backend/db/db_setup.sql`) are unchanged.

## Note

To make this actually block a merge, add it as a **required status check** for `main` in branch protection. With the path filter kept, it only runs/blocks on PRs that touch `db_setup.sql`.

`lambda-readme.yml` uses the same odd `workflow_run` pattern (README gen chained off terraform-plan, running in main context) — out of scope here, flagged for a possible follow-up.

## Test

- YAML validated locally.
- E2E: open a PR editing `apps/backend/db/db_setup.sql`, confirm the workflow runs, regenerates `shared/types/db-types.d.ts`, and pushes the commit to the PR branch (not main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)