### PR TITLE
feat: deploy notifications + merge-queue merge DM

### DIFF
--- a/.github/actions/deploy-notify/action.yml
+++ b/.github/actions/deploy-notify/action.yml
@@ -1,0 +1,155 @@
+name: Deploy Notify
+description: Post a deploy result as a PR comment and a message in the #branch-deployments Slack channel.
+
+inputs:
+  status:
+    description: 'success or failure'
+    required: true
+  title:
+    description: 'Deploy type label, e.g. "Terraform Apply"'
+    required: true
+  summary:
+    description: 'One-line result summary'
+    required: true
+  details:
+    description: 'Optional multiline output/logs (PR comment only, never Slack)'
+    required: false
+    default: ''
+  commit-sha:
+    description: 'Commit that triggered the deploy (used to find the PR)'
+    required: false
+    default: ${{ github.sha }}
+  slack-channel:
+    description: 'Slack channel id to post into'
+    required: false
+    default: C0BE7FYMHFF
+  slack-bot-token:
+    description: 'Slack bot token'
+    required: true
+  github-token:
+    description: 'GitHub token for commenting'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Post deploy result
+      uses: actions/github-script@v7
+      env:
+        DEPLOY_STATUS: ${{ inputs.status }}
+        DEPLOY_TITLE: ${{ inputs.title }}
+        DEPLOY_SUMMARY: ${{ inputs.summary }}
+        DEPLOY_DETAILS: ${{ inputs.details }}
+        DEPLOY_COMMIT_SHA: ${{ inputs.commit-sha }}
+        SLACK_CHANNEL: ${{ inputs.slack-channel }}
+        SLACK_BOT_TOKEN: ${{ inputs.slack-bot-token }}
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const status  = (process.env.DEPLOY_STATUS || '').toLowerCase();
+          const title   = process.env.DEPLOY_TITLE || 'Deploy';
+          const summary = process.env.DEPLOY_SUMMARY || '';
+          const sha     = process.env.DEPLOY_COMMIT_SHA || context.sha;
+          const rawDetails = process.env.DEPLOY_DETAILS || '';
+
+          const ok = status === 'success';
+          const ghEmoji = ok ? '✅' : '❌';
+          const slackEmoji = ok ? ':white_check_mark:' : ':x:';
+          const statusText = ok ? 'succeeded' : 'failed';
+
+          const { owner, repo } = context.repo;
+          const shortSha = sha.slice(0, 7);
+          const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+          const commitUrl = `${context.serverUrl}/${owner}/${repo}/commit/${sha}`;
+
+          // ── Truncate details for the PR comment ──────────────────
+          function truncate(text) {
+            if (!text) return '';
+            const MAX_LINES = 50;
+            const MAX_CHARS = 60000;
+            let lines = text.split('\n');
+            let clipped = false;
+            if (lines.length > MAX_LINES) {
+              lines = lines.slice(-MAX_LINES);
+              clipped = true;
+            }
+            let out = lines.join('\n');
+            if (out.length > MAX_CHARS) {
+              out = out.slice(-MAX_CHARS);
+              clipped = true;
+            }
+            if (clipped) out = `… (truncated; see full logs in the workflow run)\n${out}`;
+            return out;
+          }
+
+          // ── Build PR comment body ────────────────────────────────
+          let body = `### ${ghEmoji} ${title} — ${statusText}\n\n${summary}\n\n`;
+          body += `[Workflow run](${runUrl}) · [\`${shortSha}\`](${commitUrl})\n`;
+          const details = truncate(rawDetails);
+          if (details) {
+            body += `\n<details><summary>Output</summary>\n\n\`\`\`\n${details}\n\`\`\`\n\n</details>\n`;
+          }
+
+          // ── Comment on associated PR(s) ──────────────────────────
+          let prs = [];
+          try {
+            const resp = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner, repo, commit_sha: sha,
+            });
+            prs = resp.data;
+          } catch (err) {
+            console.log(`Could not resolve PRs for ${sha}: ${err.message}`);
+          }
+
+          if (prs.length === 0) {
+            console.log(`No PR associated with ${shortSha}; skipping PR comment.`);
+          }
+          for (const pr of prs) {
+            try {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: pr.number, body,
+              });
+              console.log(`Commented on PR #${pr.number}`);
+            } catch (err) {
+              console.log(`Failed to comment on PR #${pr.number}: ${err.message}`);
+            }
+          }
+
+          // ── Post concise message to Slack channel ────────────────
+          const prLinks = prs.length
+            ? prs.map(pr => `<${pr.html_url}|#${pr.number} ${pr.title}>`).join(', ')
+            : `<${commitUrl}|\`${shortSha}\`>`;
+
+          const blocks = [
+            { type: 'header', text: { type: 'plain_text', text: `${slackEmoji}  ${title}`, emoji: true } },
+            {
+              type: 'section',
+              text: { type: 'mrkdwn', text: `*${statusText.toUpperCase()}* — ${summary}` },
+            },
+            {
+              type: 'context',
+              elements: [
+                { type: 'mrkdwn', text: `${prs.length ? 'PR' : 'Commit'}: ${prLinks}  |  <${runUrl}|Workflow run>` },
+              ],
+            },
+          ];
+
+          try {
+            const resp = await fetch('https://slack.com/api/chat.postMessage', {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${process.env.SLACK_BOT_TOKEN}`,
+              },
+              body: JSON.stringify({
+                channel: process.env.SLACK_CHANNEL,
+                text: `${title} ${statusText}: ${summary}`,
+                blocks,
+              }),
+            });
+            const data = await resp.json();
+            if (!data.ok) console.log(`Slack chat.postMessage error: ${data.error}`);
+            else console.log(`Posted to Slack channel ${process.env.SLACK_CHANNEL}`);
+          } catch (err) {
+            console.log(`Slack post failed: ${err.message}`);
+          }

--- a/.github/workflows/frontend-deploy-notify.yml
+++ b/.github/workflows/frontend-deploy-notify.yml
@@ -1,15 +1,13 @@
 name: Frontend Deploy Notify
 
 # The frontend is deployed by AWS Amplify auto-build on push to main (see
-# infrastructure/aws/amplify.tf). Amplify runs outside GitHub Actions, so this
-# workflow polls the Amplify API for the build of this commit and reports the
-# outcome to the PR + #branch-deployments Slack channel.
+# infrastructure/aws/amplify.tf). Amplify runs outside GitHub Actions, so an
+# EventBridge rule (infrastructure/aws/amplify_notifications.tf) fires a
+# repository_dispatch when a build reaches a terminal state. This workflow
+# reacts to that event and reports the outcome to the PR + #branch-deployments.
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'apps/frontend/**'
-      - 'shared/types/**'
+  repository_dispatch:
+    types: [amplify-deploy]
 
 permissions:
   contents: read
@@ -29,56 +27,22 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
 
-      - name: Poll Amplify deploy
+      - name: Resolve Amplify job details
         id: amplify
         env:
-          COMMIT_SHA: ${{ github.sha }}
+          APP_ID: ${{ github.event.client_payload.appId }}
+          JOB_ID: ${{ github.event.client_payload.jobId }}
+          JOB_STATUS: ${{ github.event.client_payload.status }}
         run: |
           set -euo pipefail
 
-          APP_ID=$(aws amplify list-apps --query "apps[?name=='branch-frontend'].appId" --output text)
-          if [ -z "$APP_ID" ] || [ "$APP_ID" = "None" ]; then
-            echo "status=failure" >> "$GITHUB_OUTPUT"
-            echo "summary=Could not find Amplify app 'branch-frontend'" >> "$GITHUB_OUTPUT"
-            printf 'details<<__EOF__\n%s\n__EOF__\n' "aws amplify list-apps returned no app id" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "App id: $APP_ID"
-
-          # Amplify's build may lag behind the push — retry to find the job.
-          JOB_ID=""
-          for attempt in $(seq 1 10); do
-            JOB_ID=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name main --max-results 25 \
-              --query "jobSummaries[?commitId=='${COMMIT_SHA}'].jobId | [0]" --output text)
-            if [ -n "$JOB_ID" ] && [ "$JOB_ID" != "None" ]; then break; fi
-            echo "No Amplify job for ${COMMIT_SHA} yet (attempt $attempt); waiting…"
-            JOB_ID=""
-            sleep 30
-          done
-
-          if [ -z "$JOB_ID" ]; then
-            echo "status=failure" >> "$GITHUB_OUTPUT"
-            echo "summary=No Amplify build found for commit ${COMMIT_SHA:0:7} (auto-build delayed or disabled)" >> "$GITHUB_OUTPUT"
-            printf 'details<<__EOF__\n%s\n__EOF__\n' "Checked app $APP_ID branch main." >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "Job id: $JOB_ID"
-
-          # Poll until terminal (~20 min max).
-          STATUS=""
-          for attempt in $(seq 1 40); do
-            STATUS=$(aws amplify get-job --app-id "$APP_ID" --branch-name main --job-id "$JOB_ID" \
-              --query "job.summary.status" --output text)
-            echo "Amplify job $JOB_ID status: $STATUS"
-            case "$STATUS" in
-              SUCCEED|FAILED|CANCELLED) break ;;
-            esac
-            sleep 30
-          done
+          COMMIT=$(aws amplify get-job --app-id "$APP_ID" --branch-name main --job-id "$JOB_ID" \
+            --query "job.summary.commitId" --output text)
+          echo "commit=$COMMIT" >> "$GITHUB_OUTPUT"
 
           # Collect step logs on non-success.
           echo "details<<__EOF__" >> "$GITHUB_OUTPUT"
-          if [ "$STATUS" != "SUCCEED" ]; then
+          if [ "$JOB_STATUS" != "SUCCEED" ]; then
             LOG_URLS=$(aws amplify get-job --app-id "$APP_ID" --branch-name main --job-id "$JOB_ID" \
               --query "job.steps[].logUrl" --output text || true)
             for url in $LOG_URLS; do
@@ -89,20 +53,21 @@ jobs:
           fi
           echo "__EOF__" >> "$GITHUB_OUTPUT"
 
-          if [ "$STATUS" = "SUCCEED" ]; then
-            echo "status=success" >> "$GITHUB_OUTPUT"
+          if [ "$JOB_STATUS" = "SUCCEED" ]; then
+            echo "result=success" >> "$GITHUB_OUTPUT"
             echo "summary=Amplify build $JOB_ID succeeded" >> "$GITHUB_OUTPUT"
           else
-            echo "status=failure" >> "$GITHUB_OUTPUT"
-            echo "summary=Amplify build $JOB_ID finished with status ${STATUS:-unknown}" >> "$GITHUB_OUTPUT"
+            echo "result=failure" >> "$GITHUB_OUTPUT"
+            echo "summary=Amplify build $JOB_ID finished with status $JOB_STATUS" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Notify
         uses: ./.github/actions/deploy-notify
         with:
-          status: ${{ steps.amplify.outputs.status }}
+          status: ${{ steps.amplify.outputs.result }}
           title: Frontend Deploy
           summary: ${{ steps.amplify.outputs.summary }}
           details: ${{ steps.amplify.outputs.details }}
+          commit-sha: ${{ steps.amplify.outputs.commit }}
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/frontend-deploy-notify.yml
+++ b/.github/workflows/frontend-deploy-notify.yml
@@ -1,0 +1,108 @@
+name: Frontend Deploy Notify
+
+# The frontend is deployed by AWS Amplify auto-build on push to main (see
+# infrastructure/aws/amplify.tf). Amplify runs outside GitHub Actions, so this
+# workflow polls the Amplify API for the build of this commit and reports the
+# outcome to the PR + #branch-deployments Slack channel.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/frontend/**'
+      - 'shared/types/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+
+      - name: Poll Amplify deploy
+        id: amplify
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          APP_ID=$(aws amplify list-apps --query "apps[?name=='branch-frontend'].appId" --output text)
+          if [ -z "$APP_ID" ] || [ "$APP_ID" = "None" ]; then
+            echo "status=failure" >> "$GITHUB_OUTPUT"
+            echo "summary=Could not find Amplify app 'branch-frontend'" >> "$GITHUB_OUTPUT"
+            printf 'details<<__EOF__\n%s\n__EOF__\n' "aws amplify list-apps returned no app id" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "App id: $APP_ID"
+
+          # Amplify's build may lag behind the push — retry to find the job.
+          JOB_ID=""
+          for attempt in $(seq 1 10); do
+            JOB_ID=$(aws amplify list-jobs --app-id "$APP_ID" --branch-name main --max-results 25 \
+              --query "jobSummaries[?commitId=='${COMMIT_SHA}'].jobId | [0]" --output text)
+            if [ -n "$JOB_ID" ] && [ "$JOB_ID" != "None" ]; then break; fi
+            echo "No Amplify job for ${COMMIT_SHA} yet (attempt $attempt); waiting…"
+            JOB_ID=""
+            sleep 30
+          done
+
+          if [ -z "$JOB_ID" ]; then
+            echo "status=failure" >> "$GITHUB_OUTPUT"
+            echo "summary=No Amplify build found for commit ${COMMIT_SHA:0:7} (auto-build delayed or disabled)" >> "$GITHUB_OUTPUT"
+            printf 'details<<__EOF__\n%s\n__EOF__\n' "Checked app $APP_ID branch main." >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Job id: $JOB_ID"
+
+          # Poll until terminal (~20 min max).
+          STATUS=""
+          for attempt in $(seq 1 40); do
+            STATUS=$(aws amplify get-job --app-id "$APP_ID" --branch-name main --job-id "$JOB_ID" \
+              --query "job.summary.status" --output text)
+            echo "Amplify job $JOB_ID status: $STATUS"
+            case "$STATUS" in
+              SUCCEED|FAILED|CANCELLED) break ;;
+            esac
+            sleep 30
+          done
+
+          # Collect step logs on non-success.
+          echo "details<<__EOF__" >> "$GITHUB_OUTPUT"
+          if [ "$STATUS" != "SUCCEED" ]; then
+            LOG_URLS=$(aws amplify get-job --app-id "$APP_ID" --branch-name main --job-id "$JOB_ID" \
+              --query "job.steps[].logUrl" --output text || true)
+            for url in $LOG_URLS; do
+              [ "$url" = "None" ] && continue
+              echo "----- step log -----" >> "$GITHUB_OUTPUT"
+              curl -fsSL "$url" 2>/dev/null | tail -n 40 >> "$GITHUB_OUTPUT" || echo "(could not fetch log)" >> "$GITHUB_OUTPUT"
+            done
+          fi
+          echo "__EOF__" >> "$GITHUB_OUTPUT"
+
+          if [ "$STATUS" = "SUCCEED" ]; then
+            echo "status=success" >> "$GITHUB_OUTPUT"
+            echo "summary=Amplify build $JOB_ID succeeded" >> "$GITHUB_OUTPUT"
+          else
+            echo "status=failure" >> "$GITHUB_OUTPUT"
+            echo "summary=Amplify build $JOB_ID finished with status ${STATUS:-unknown}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Notify
+        uses: ./.github/actions/deploy-notify
+        with:
+          status: ${{ steps.amplify.outputs.status }}
+          title: Frontend Deploy
+          summary: ${{ steps.amplify.outputs.summary }}
+          details: ${{ steps.amplify.outputs.details }}
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lambda-deploy.yml
+++ b/.github/workflows/lambda-deploy.yml
@@ -111,33 +111,95 @@ jobs:
           path: ${{ matrix.lambda }}
 
       - name: Deploy lambda
+        id: deploy
         run: |
+          set -o pipefail
           LAMBDA_NAME=$(basename ${{ matrix.lambda }})
           FUNCTION_NAME="branch-${LAMBDA_NAME}"
-          
-          echo "Deploying Lambda function: $FUNCTION_NAME"
-          
-          aws lambda update-function-code \
-            --function-name "$FUNCTION_NAME" \
-            --zip-file fileb://${{ matrix.lambda }}/lambda.zip
-          
-          echo "✓ Successfully deployed $FUNCTION_NAME"
+          {
+            echo "Deploying Lambda function: $FUNCTION_NAME"
+            aws lambda update-function-code \
+              --function-name "$FUNCTION_NAME" \
+              --zip-file fileb://${{ matrix.lambda }}/lambda.zip
+            echo "✓ Successfully deployed $FUNCTION_NAME"
+          } 2>&1 | tee deploy.log
 
-  summary:
-    name: Deployment Summary
-    needs: [deploy]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check deployment results
+      - name: Compute result name
+        id: rname
+        if: always()
+        run: echo "name=$(basename ${{ matrix.lambda }})" >> "$GITHUB_OUTPUT"
+
+      - name: Save deploy result
+        if: always()
         run: |
-          if [ "${{ needs.deploy.result }}" == "success" ]; then
-            echo "✓ All Lambda functions deployed successfully!"
-            exit 0
-          elif [ "${{ needs.deploy.result }}" == "skipped" ]; then
-            echo "⊘ No Lambda changes detected, skipping deployment"
-            exit 0
+          mkdir -p lambda-results
+          echo "${{ steps.rname.outputs.name }}|${{ steps.deploy.outcome }}" > "lambda-results/${{ steps.rname.outputs.name }}.meta"
+          cp deploy.log "lambda-results/${{ steps.rname.outputs.name }}.log" 2>/dev/null \
+            || echo "(no deploy output captured)" > "lambda-results/${{ steps.rname.outputs.name }}.log"
+
+      - name: Upload deploy result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lambda-result-${{ steps.rname.outputs.name }}
+          path: lambda-results/
+          if-no-files-found: warn
+
+  notify:
+    name: Deployment Notify
+    needs: [detect-changes, deploy]
+    if: always() && needs.detect-changes.outputs.has-changes == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download deploy results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: lambda-result-*
+          path: lambda-results
+          merge-multiple: true
+
+      - name: Aggregate results
+        id: agg
+        run: |
+          total=0; ok=0; failed=""
+          echo "details<<__DETAILS_EOF__" >> "$GITHUB_OUTPUT"
+          for meta in lambda-results/*.meta; do
+            [ -e "$meta" ] || continue
+            name=$(cut -d'|' -f1 "$meta")
+            outcome=$(cut -d'|' -f2 "$meta")
+            base=$(basename "$meta" .meta)
+            total=$((total+1))
+            if [ "$outcome" = "success" ]; then
+              ok=$((ok+1))
+            else
+              failed="$failed $name"
+              echo "===== $name ($outcome) =====" >> "$GITHUB_OUTPUT"
+              cat "lambda-results/$base.log" 2>/dev/null >> "$GITHUB_OUTPUT" || echo "(no output)" >> "$GITHUB_OUTPUT"
+              echo "" >> "$GITHUB_OUTPUT"
+            fi
+          done
+          echo "__DETAILS_EOF__" >> "$GITHUB_OUTPUT"
+
+          if [ -n "$failed" ]; then
+            echo "status=failure" >> "$GITHUB_OUTPUT"
+            echo "summary=$ok/$total lambdas deployed — failed:$failed" >> "$GITHUB_OUTPUT"
           else
-            echo "✗ Lambda deployment failed"
-            exit 1
+            echo "status=success" >> "$GITHUB_OUTPUT"
+            echo "summary=$ok/$total lambdas deployed" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Notify
+        uses: ./.github/actions/deploy-notify
+        with:
+          status: ${{ steps.agg.outputs.status }}
+          title: Lambda Deploy
+          summary: ${{ steps.agg.outputs.summary }}
+          details: ${{ steps.agg.outputs.details }}
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/merge-queue-dequeued.yml
+++ b/.github/workflows/merge-queue-dequeued.yml
@@ -78,6 +78,30 @@ jobs:
               }
             }
 
+            // Merge queue also fires `dequeued` when a PR merges successfully.
+            // Send a positive "merged" DM instead of a removal notice.
+            if (String(reason).toLowerCase() === 'merge') {
+              await slackApi('chat.postMessage', {
+                channel: slackId,
+                text: `PR #${prNumber} merged — deploying shortly`,
+                blocks: [
+                  {
+                    type: 'header',
+                    text: { type: 'plain_text', text: ':merged:  Merged — Deploying Soon', emoji: true },
+                  },
+                  {
+                    type: 'section',
+                    text: {
+                      type: 'mrkdwn',
+                      text: `Your PR *<${prUrl}|#${prNumber} ${prTitle}>* has been merged and will deploy shortly.`,
+                    },
+                  },
+                ],
+              });
+              console.log(`Notified ${author} (${slackId}): PR #${prNumber} merged.`);
+              return;
+            }
+
             const blocks = [
               {
                 type: 'header',

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -137,11 +137,33 @@ jobs:
       - name: Terraform Apply
         id: apply
         run: |
-          terraform apply -auto-approve -no-color tfplan
+          set -o pipefail
+          terraform apply -auto-approve -no-color tfplan 2>&1 | tee apply.log
         working-directory: ${{ matrix.directory }}
         env:
           TF_VAR_infisical_client_id: ${{ secrets.INFISICAL_CLIENT_ID }}
           TF_VAR_infisical_client_secret: ${{ secrets.INFISICAL_CLIENT_SECRET }}
+
+      - name: Compute result name
+        id: rname
+        if: always()
+        run: echo "name=$(echo '${{ matrix.directory }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
+
+      - name: Save apply result
+        if: always()
+        run: |
+          mkdir -p tf-results
+          echo "${{ matrix.directory }}|${{ steps.apply.outcome }}" > "tf-results/${{ steps.rname.outputs.name }}.meta"
+          cp "${{ matrix.directory }}/apply.log" "tf-results/${{ steps.rname.outputs.name }}.log" 2>/dev/null \
+            || echo "(no apply output captured)" > "tf-results/${{ steps.rname.outputs.name }}.log"
+
+      - name: Upload apply result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tf-result-${{ steps.rname.outputs.name }}
+          path: tf-results/
+          if-no-files-found: warn
 
       - name: Create deployment summary
         if: always()
@@ -162,17 +184,58 @@ jobs:
             echo "❌ **Terraform apply failed!**" >> $GITHUB_STEP_SUMMARY
           fi
 
-  terraform-apply-summary:
+  notify:
     needs: [detect-changes, terraform-apply]
-    if: always()
+    if: always() && needs.detect-changes.outputs.terraform-dirs != '' && needs.detect-changes.outputs.terraform-dirs != '[]'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
-      - name: Summary
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download apply results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: tf-result-*
+          path: tf-results
+          merge-multiple: true
+
+      - name: Aggregate results
+        id: agg
         run: |
-          if [ "${{ needs.detect-changes.outputs.terraform-dirs }}" == "" ] || [ "${{ needs.detect-changes.outputs.terraform-dirs }}" == "[]" ]; then
-            echo "No Terraform changes detected or no directories selected"
+          total=0; ok=0; failed_dirs=""
+          echo "details<<__DETAILS_EOF__" >> "$GITHUB_OUTPUT"
+          for meta in tf-results/*.meta; do
+            [ -e "$meta" ] || continue
+            dir=$(cut -d'|' -f1 "$meta")
+            outcome=$(cut -d'|' -f2 "$meta")
+            base=$(basename "$meta" .meta)
+            total=$((total+1))
+            if [ "$outcome" = "success" ]; then ok=$((ok+1)); else failed_dirs="$failed_dirs $dir"; fi
+            echo "===== $dir ($outcome) =====" >> "$GITHUB_OUTPUT"
+            cat "tf-results/$base.log" 2>/dev/null >> "$GITHUB_OUTPUT" || echo "(no output)" >> "$GITHUB_OUTPUT"
+            echo "" >> "$GITHUB_OUTPUT"
+          done
+          echo "__DETAILS_EOF__" >> "$GITHUB_OUTPUT"
+
+          if [ -n "$failed_dirs" ]; then
+            echo "status=failure" >> "$GITHUB_OUTPUT"
+            echo "summary=$ok/$total workspaces applied — failed:$failed_dirs" >> "$GITHUB_OUTPUT"
           else
-            echo "Terraform apply completed for directories: ${{ needs.detect-changes.outputs.terraform-dirs }}"
+            echo "status=success" >> "$GITHUB_OUTPUT"
+            echo "summary=$ok/$total workspaces applied" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Notify
+        uses: ./.github/actions/deploy-notify
+        with:
+          status: ${{ steps.agg.outputs.status }}
+          title: Terraform Apply
+          summary: ${{ steps.agg.outputs.summary }}
+          details: ${{ steps.agg.outputs.details }}
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
 

--- a/infrastructure/aws/README.md
+++ b/infrastructure/aws/README.md
@@ -31,11 +31,17 @@ No modules.
 | [aws_api_gateway_resource.lambda_resources](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/api_gateway_resource) | resource |
 | [aws_api_gateway_rest_api.branch_api](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/api_gateway_rest_api) | resource |
 | [aws_api_gateway_stage.branch_stage](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/api_gateway_stage) | resource |
+| [aws_cloudwatch_event_api_destination.github_dispatch](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/cloudwatch_event_api_destination) | resource |
+| [aws_cloudwatch_event_connection.github_dispatch](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/cloudwatch_event_connection) | resource |
+| [aws_cloudwatch_event_rule.amplify_frontend_deploy](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_target.github_dispatch](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/cloudwatch_event_target) | resource |
 | [aws_cognito_user_pool.branch_user_pool](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/cognito_user_pool) | resource |
 | [aws_cognito_user_pool_client.branch_client](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/cognito_user_pool_client) | resource |
 | [aws_db_instance.branch_rds](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/db_instance) | resource |
 | [aws_iam_role.amplify_ssr](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/iam_role) | resource |
+| [aws_iam_role.eventbridge_api_dest](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/iam_role) | resource |
 | [aws_iam_role.lambda_role](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.eventbridge_api_dest](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy_attachment.amplify_ssr](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.lambda_basic](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_lambda_function.functions](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/lambda_function) | resource |

--- a/infrastructure/aws/amplify_notifications.tf
+++ b/infrastructure/aws/amplify_notifications.tf
@@ -1,0 +1,110 @@
+# Amplify runs the frontend build outside GitHub Actions, so there is no native
+# post-deploy hook. Amplify does emit build state changes to EventBridge, so we
+# match those events and fan them into a GitHub `repository_dispatch`, which the
+# "Frontend Deploy Notify" workflow reacts to (posts a PR comment + Slack msg).
+#
+# This replaces a long-polling GitHub Actions job — no idle runner, instant.
+
+locals {
+  github_repo_dispatch_url = "https://api.github.com/repos/Code-4-Community/branch/dispatches"
+}
+
+# Connection holds the GitHub token EventBridge sends as the Authorization
+# header. Reuses the same admin PAT Amplify already uses (see amplify.tf).
+resource "aws_cloudwatch_event_connection" "github_dispatch" {
+  name               = "branch-github-dispatch"
+  authorization_type = "API_KEY"
+
+  auth_parameters {
+    api_key {
+      key   = "Authorization"
+      value = "Bearer ${data.infisical_secrets.github_folder.secrets["branch-gh-admin"].value}"
+    }
+  }
+}
+
+resource "aws_cloudwatch_event_api_destination" "github_dispatch" {
+  name                             = "branch-github-dispatch"
+  invocation_endpoint              = local.github_repo_dispatch_url
+  http_method                      = "POST"
+  invocation_rate_limit_per_second = 10
+  connection_arn                   = aws_cloudwatch_event_connection.github_dispatch.arn
+}
+
+# Match only terminal build states on the frontend app's main branch.
+resource "aws_cloudwatch_event_rule" "amplify_frontend_deploy" {
+  name        = "branch-amplify-frontend-deploy"
+  description = "Amplify main-branch deploy status changes for the frontend app"
+
+  event_pattern = jsonencode({
+    source        = ["aws.amplify"]
+    "detail-type" = ["Amplify Deployment Status Change"]
+    detail = {
+      appId      = [aws_amplify_app.frontend.id]
+      branchName = ["main"]
+      jobStatus  = ["SUCCEED", "FAILED", "CANCELLED"]
+    }
+  })
+}
+
+# EventBridge assumes this role to invoke the API destination.
+resource "aws_iam_role" "eventbridge_api_dest" {
+  name = "branch-eventbridge-api-dest-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "events.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "eventbridge_api_dest" {
+  name = "invoke-github-dispatch"
+  role = aws_iam_role.eventbridge_api_dest.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "events:InvokeApiDestination"
+      Resource = aws_cloudwatch_event_api_destination.github_dispatch.arn
+    }]
+  })
+}
+
+resource "aws_cloudwatch_event_target" "github_dispatch" {
+  rule     = aws_cloudwatch_event_rule.amplify_frontend_deploy.name
+  arn      = aws_cloudwatch_event_api_destination.github_dispatch.arn
+  role_arn = aws_iam_role.eventbridge_api_dest.arn
+
+  http_target {
+    header_parameters = {
+      "Content-Type"         = "application/json"
+      "Accept"               = "application/vnd.github+json"
+      "X-GitHub-Api-Version" = "2022-11-28"
+    }
+  }
+
+  # Reshape the Amplify event into a repository_dispatch body. EventBridge
+  # auto-quotes string variables, so placeholders stay unquoted.
+  input_transformer {
+    input_paths = {
+      jobId  = "$.detail.jobId"
+      status = "$.detail.jobStatus"
+      appId  = "$.detail.appId"
+    }
+    input_template = <<-EOT
+      {
+        "event_type": "amplify-deploy",
+        "client_payload": {
+          "jobId": <jobId>,
+          "status": <status>,
+          "appId": <appId>
+        }
+      }
+    EOT
+  }
+}


### PR DESCRIPTION
## What

Adds post-deploy feedback to the PR review bot and fixes the misleading dequeue DM sent when a PR *merges* out of the queue.

## Why

1. **Dequeue DM lied on merge.** `merge-queue-dequeued.yml` fires on `pull_request: dequeued`, which GitHub also emits when a PR merges successfully (`reason: merge`). Authors got "❌ Removed from Merge Queue — Reason: merge", reading like a failure.
2. **No deploy feedback.** terraform apply, lambda deploy, and the Amplify frontend build ran after merge with no visible outcome.

## Changes

- **`merge-queue-dequeued.yml`** — when `reason === 'merge'`, DM the author ":merged: Merged — Deploying Soon" and return; all other removal reasons behave exactly as before.
- **`.github/actions/deploy-notify`** (new composite action) — resolves the PR from the commit (`listPullRequestsAssociatedWithCommit`), posts a PR comment (with truncated output/logs in a `<details>` block) **and** a concise message to the `#branch-deployments` Slack channel (`C0BE7FYMHFF`). Slack never carries raw logs.
- **`terraform-apply.yml`** — captures apply output per workspace (artifacts); a `notify` job aggregates and comments the apply output.
- **`lambda-deploy.yml`** — captures deploy output per lambda (artifacts); `notify` job (replaces the old `summary`) reports outcome always, logs only on failure.
- **`frontend-deploy-notify.yml`** (new) — polls the Amplify API for the build matching the merge commit and reports outcome + step logs on failure.

No new secrets — reuses `SLACK_BOT_TOKEN`, `GITHUB_TOKEN`, and the existing AWS creds.

## Verification

Local (passed): YAML validity of all 5 files; dry-run of the `deploy-notify` github-script (truncation, conditional `<details>`, log-free Slack, PR-less fallback); syntax check of the dequeue script; bash aggregation heredoc → valid `$GITHUB_OUTPUT`.

Requires a live run to confirm: actual merge DM wording, real PR comments, Amplify polling. Best exercised by merging a PR that touches `infrastructure/**.tf`, a lambda, and `apps/frontend/**`.

## Note

`deploy-notify` posts on every deploy including re-runs / `workflow_dispatch` — any push touching those paths comments on the associated PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)