### PR TITLE
fix: Amplify SSR role assume (sts:TagSession) + build only on frontend changes

### DIFF
--- a/infrastructure/aws/amplify.tf
+++ b/infrastructure/aws/amplify.tf
@@ -5,7 +5,10 @@ resource "aws_iam_role" "amplify_ssr" {
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{
-      Action    = "sts:AssumeRole"
+      # sts:TagSession is required alongside AssumeRole — Amplify attaches
+      # session tags when assuming the service role; without it the assume is
+      # denied ("Unable to assume specified IAM Role").
+      Action    = ["sts:AssumeRole", "sts:TagSession"]
       Effect    = "Allow"
       Principal = { Service = "amplify.amazonaws.com" }
     }]
@@ -24,27 +27,31 @@ resource "aws_amplify_app" "frontend" {
   platform             = "WEB_COMPUTE"
   iam_service_role_arn = aws_iam_role.amplify_ssr.arn
 
+  # Monorepo build spec: the `applications`/`appRoot` form makes Amplify build
+  # from apps/frontend AND skip builds when no files under that root changed —
+  # so backend/infra pushes to main don't trigger a frontend deploy.
   build_spec = <<-EOT
     version: 1
-    frontend:
-      phases:
-        preBuild:
-          commands:
-            - npm ci
-        build:
-          commands:
-            - npm run build
-      artifacts:
-        baseDirectory: .next
-        files:
-          - '**/*'
-      cache:
-        paths:
-          - .next/cache/**/*
+    applications:
+      - appRoot: apps/frontend
+        frontend:
+          phases:
+            preBuild:
+              commands:
+                - npm ci
+            build:
+              commands:
+                - npm run build
+          artifacts:
+            baseDirectory: .next
+            files:
+              - '**/*'
+          cache:
+            paths:
+              - .next/cache/**/*
   EOT
 
   environment_variables = {
-    AMPLIFY_MONOREPO_APP_ROOT = "apps/frontend"
     # Default the API base URL to the deployed API Gateway stage so the built
     # frontend talks to the real backend instead of localhost. var.api_base_url
     # still overrides when set (was previously "" -> apiFetch hit localhost).


### PR DESCRIPTION
## Why

Amplify builds fail instantly with:
```
!!! Unable to assume specified IAM Role. Please ensure the selected IAM Role has sufficient permissions and the Trust Relationship is configured correctly.
```
Verified in-account: the trust is correct (`Principal: amplify.amazonaws.com`, `Action: sts:AssumeRole`) and the app's `iamServiceRoleArn` points at `branch-amplify-ssr-role`. So the trust *content* isn't the issue — Amplify attaches **session tags** when assuming the service role, which requires the trust to also allow **`sts:TagSession`**. Without it STS denies the assume with this generic message.

## What

- Add `sts:TagSession` to the SSR role trust policy (alongside `sts:AssumeRole`).
- Switch the monorepo build spec to the `applications` / `appRoot: apps/frontend` form. Amplify then **only builds when files under `apps/frontend` change** — backend/infra/doc pushes to `main` no longer trigger a frontend deploy. Drops the now-redundant `AMPLIFY_MONOREPO_APP_ROOT` env var.

## After merge

`terraform-apply` updates the role trust + build spec. Then trigger a build (`aws amplify start-job --app-id dbcy90q4o31f7 --branch-name main --job-type RELEASE`) and it should get past the assume-role step into `npm ci` / `npm run build`.

**If it still fails to assume** after this applies, the cause is account-level (Org SCP / a required permissions boundary on IAM roles). Quick discriminator: in the Amplify console use "Create and use a new service role" — if Amplify's own role also can't be assumed, it's an SCP/boundary and we handle it there.

## Verification

- `terraform fmt` clean.
- `terraform-plan` on this PR should show only the role trust update + amplify build_spec/env update, no destroys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)