### PR TITLE
fix: add regional Amplify principal to SSR role trust

### DIFF
--- a/infrastructure/aws/amplify.tf
+++ b/infrastructure/aws/amplify.tf
@@ -8,9 +8,12 @@ resource "aws_iam_role" "amplify_ssr" {
       # sts:TagSession is required alongside AssumeRole — Amplify attaches
       # session tags when assuming the service role; without it the assume is
       # denied ("Unable to assume specified IAM Role").
-      Action    = ["sts:AssumeRole", "sts:TagSession"]
-      Effect    = "Allow"
-      Principal = { Service = "amplify.amazonaws.com" }
+      Action = ["sts:AssumeRole", "sts:TagSession"]
+      Effect = "Allow"
+      # Amplify assumes the role via BOTH the regional and global service
+      # principals; the regional one (amplify.<region>.amazonaws.com) is the
+      # documented fix for "Unable to assume specified IAM Role" on SSR apps.
+      Principal = { Service = ["amplify.us-east-2.amazonaws.com", "amplify.amazonaws.com"] }
     }]
   })
 }


### PR DESCRIPTION
## Why

`sts:TagSession` (#264) did **not** resolve the Amplify build failure:
```
!!! Unable to assume specified IAM Role.
```
The most-cited fix on AWS re:Post for Amplify **SSR** apps is to trust *both* the regional and global service principals — some Amplify build paths assume via `amplify.<region>.amazonaws.com`, not just `amplify.amazonaws.com`.

## What

Trust principal becomes:
```
Service = ["amplify.us-east-2.amazonaws.com", "amplify.amazonaws.com"]
```

## After apply

Trigger a build (`aws amplify start-job --app-id dbcy90q4o31f7 --branch-name main --job-type RELEASE --region us-east-2`) and check the log gets past the assume step.

**If it STILL fails**, the role definition is exhausted — it's the Amplify console-registration quirk / account-level. Next step is the console "create and use a new service role" discriminator (documented in the thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)