### PR TITLE
feat: GitHub OIDC provider + scoped CI roles (plan RO / apply RW)

### DIFF
--- a/infrastructure/aws/README.md
+++ b/infrastructure/aws/README.md
@@ -38,11 +38,17 @@ No modules.
 | [aws_cognito_user_pool.branch_user_pool](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/cognito_user_pool) | resource |
 | [aws_cognito_user_pool_client.branch_client](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/cognito_user_pool_client) | resource |
 | [aws_db_instance.branch_rds](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/db_instance) | resource |
+| [aws_iam_openid_connect_provider.github](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/iam_openid_connect_provider) | resource |
 | [aws_iam_role.amplify_ssr](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/iam_role) | resource |
+| [aws_iam_role.ci_apply](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/iam_role) | resource |
+| [aws_iam_role.ci_plan](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/iam_role) | resource |
 | [aws_iam_role.eventbridge_api_dest](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/iam_role) | resource |
 | [aws_iam_role.lambda_role](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.ci_plan_state_lock](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.eventbridge_api_dest](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy_attachment.amplify_ssr](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.ci_apply_admin](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.ci_plan_readonly](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.lambda_basic](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_lambda_function.functions](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/lambda_function) | resource |
 | [aws_lambda_permission.api_gateway_permissions](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/lambda_permission) | resource |
@@ -55,6 +61,8 @@ No modules.
 | [aws_s3_object.lambda_placeholder](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/s3_object) | resource |
 | [archive_file.lambda_placeholder](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.ci_apply_assume](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.ci_plan_assume](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/data-sources/iam_policy_document) | data source |
 | [infisical_secrets.github_folder](https://registry.terraform.io/providers/infisical/infisical/latest/docs/data-sources/secrets) | data source |
 | [infisical_secrets.rds_folder](https://registry.terraform.io/providers/infisical/infisical/latest/docs/data-sources/secrets) | data source |
 
@@ -72,6 +80,8 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_api_gateway_url"></a> [api\_gateway\_url](#output\_api\_gateway\_url) | The URL of the API Gateway |
+| <a name="output_ci_apply_role_arn"></a> [ci\_apply\_role\_arn](#output\_ci\_apply\_role\_arn) | OIDC role for terraform-apply / lambda-deploy (write, production env only) |
+| <a name="output_ci_plan_role_arn"></a> [ci\_plan\_role\_arn](#output\_ci\_plan\_role\_arn) | OIDC role for terraform-plan (read-only) |
 | <a name="output_cognito_region"></a> [cognito\_region](#output\_cognito\_region) | AWS Region for Cognito |
 | <a name="output_cognito_user_pool_arn"></a> [cognito\_user\_pool\_arn](#output\_cognito\_user\_pool\_arn) | Cognito User Pool ARN |
 | <a name="output_cognito_user_pool_endpoint"></a> [cognito\_user\_pool\_endpoint](#output\_cognito\_user\_pool\_endpoint) | Cognito User Pool Endpoint |

--- a/infrastructure/aws/oidc.tf
+++ b/infrastructure/aws/oidc.tf
@@ -1,0 +1,129 @@
+# GitHub Actions OIDC → scoped IAM roles.
+#
+# Replaces the long-lived branch-ci-and-iac access keys stored as GitHub
+# secrets. Two roles, split by read vs write so plans keep working on PRs while
+# the powerful write path is locked to the `production` environment:
+#
+#   branch-ci-plan   read-only, assumable from ANY workflow context (PR / branch
+#                    / merge queue). Safe to expose broadly — it can only read.
+#   branch-ci-apply  read-write, assumable ONLY from the `production` GitHub
+#                    environment (gate it further with required reviewers on that
+#                    environment). Used by terraform-apply + lambda-deploy.
+#
+# Security comes from *who can assume* (the sub condition), not from narrowing
+# the write role's policy — so a rogue workflow on a feature branch can assume at
+# most the read-only role.
+#
+# BOOTSTRAP: creating the OIDC provider + roles needs IAM perms the locked
+# branch-ci-and-iac user likely lacks (iam:CreateOpenIDConnectProvider). The
+# FIRST apply of this file must be run by an admin/broader principal; afterwards
+# CI uses these roles.
+
+locals {
+  github_repo = "Code-4-Community/branch"
+}
+
+resource "aws_iam_openid_connect_provider" "github" {
+  url            = "https://token.actions.githubusercontent.com"
+  client_id_list = ["sts.amazonaws.com"]
+  thumbprint_list = [
+    "6938fd4d98bab03faadb97b34396831e3780aea1",
+    "1c58a3a8518e8759bf075b76b750d4f2df264fca",
+  ]
+}
+
+# ---------------------------------------------------------------------------
+# Plan role — read-only, broadly assumable (PR / branch / merge queue)
+# ---------------------------------------------------------------------------
+data "aws_iam_policy_document" "ci_plan_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github.arn]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:${local.github_repo}:*"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ci_plan" {
+  name               = "branch-ci-plan"
+  assume_role_policy = data.aws_iam_policy_document.ci_plan_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "ci_plan_readonly" {
+  role       = aws_iam_role.ci_plan.name
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+# terraform plan is read-only except that it acquires the DynamoDB state lock.
+resource "aws_iam_role_policy" "ci_plan_state_lock" {
+  name = "tfstate-lock"
+  role = aws_iam_role.ci_plan.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:DeleteItem"]
+      Resource = "arn:aws:dynamodb:*:${data.aws_caller_identity.current.account_id}:table/terraform-state-lock"
+    }]
+  })
+}
+
+# ---------------------------------------------------------------------------
+# Apply role — read-write, assumable ONLY from the `production` environment
+# ---------------------------------------------------------------------------
+data "aws_iam_policy_document" "ci_apply_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github.arn]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:${local.github_repo}:environment:production"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ci_apply" {
+  name               = "branch-ci-apply"
+  assume_role_policy = data.aws_iam_policy_document.ci_apply_assume.json
+}
+
+# Broad perms are acceptable here because assumption is locked to the production
+# environment (+ required reviewers). Tightening to specific services is a
+# follow-up; keeping it broad avoids the missing-permission whack-a-mole the
+# scoped branch-ci-and-iac user hit.
+resource "aws_iam_role_policy_attachment" "ci_apply_admin" {
+  role       = aws_iam_role.ci_apply.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+output "ci_plan_role_arn" {
+  description = "OIDC role for terraform-plan (read-only)"
+  value       = aws_iam_role.ci_plan.arn
+}
+
+output "ci_apply_role_arn" {
+  description = "OIDC role for terraform-apply / lambda-deploy (write, production env only)"
+  value       = aws_iam_role.ci_apply.arn
+}

--- a/infrastructure/aws/oidc.tf
+++ b/infrastructure/aws/oidc.tf
@@ -1,24 +1,3 @@
-# GitHub Actions OIDC → scoped IAM roles.
-#
-# Replaces the long-lived branch-ci-and-iac access keys stored as GitHub
-# secrets. Two roles, split by read vs write so plans keep working on PRs while
-# the powerful write path is locked to the `production` environment:
-#
-#   branch-ci-plan   read-only, assumable from ANY workflow context (PR / branch
-#                    / merge queue). Safe to expose broadly — it can only read.
-#   branch-ci-apply  read-write, assumable ONLY from the `production` GitHub
-#                    environment (gate it further with required reviewers on that
-#                    environment). Used by terraform-apply + lambda-deploy.
-#
-# Security comes from *who can assume* (the sub condition), not from narrowing
-# the write role's policy — so a rogue workflow on a feature branch can assume at
-# most the read-only role.
-#
-# BOOTSTRAP: creating the OIDC provider + roles needs IAM perms the locked
-# branch-ci-and-iac user likely lacks (iam:CreateOpenIDConnectProvider). The
-# FIRST apply of this file must be run by an admin/broader principal; afterwards
-# CI uses these roles.
-
 locals {
   github_repo = "Code-4-Community/branch"
 }


### PR DESCRIPTION
## Why

The CI AWS creds are long-lived `branch-ci-and-iac` keys stored as GitHub secrets. Any workflow that runs in the repo (any branch push by anyone with write access) can read them — and that user has `iam:PassRole:*` + `events:*` + Secrets Manager. So write access ≈ full infra access.

## What (this PR = the roles only)

GitHub OIDC provider + two roles, split by trust so plans keep working while write is locked down:

- **`branch-ci-plan`** — `ReadOnlyAccess` (+ DynamoDB state-lock). Trust `sub` = `repo:Code-4-Community/branch:*` (any PR/branch/merge-queue). Safe broad — read-only.
- **`branch-ci-apply`** — `AdministratorAccess`. Trust `sub` = `repo:Code-4-Community/branch:environment:production` **only**. Security is the *assume condition*, not policy narrowness — a rogue feature-branch workflow can assume at most the read-only role.

## ⚠️ Sequencing

1. **Merge + apply THIS PR first** so the roles exist.
2. **Bootstrap:** the first apply needs an admin/broader principal — `iam:CreateOpenIDConnectProvider` + role creation are likely outside `branch-ci-and-iac`'s allow-list (same class of denial you've been hitting).
3. Then merge the workflow-cutover PR (#B) which points the workflows at these roles.
4. After cutover verified, delete the `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` GitHub secrets.

## Follow-ups
- Add **required reviewers** to the `production` GitHub environment for the approval gate (I can codify in `infrastructure/github`).
- Tighten `branch-ci-apply` from `AdministratorAccess` to specific services once stable.
- Scope the Infisical CI token to read-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)