### PR TITLE
feat: cut CI workflows over to OIDC roles (no static AWS keys)

### DIFF
--- a/.github/workflows/lambda-deploy.yml
+++ b/.github/workflows/lambda-deploy.yml
@@ -91,14 +91,14 @@ jobs:
     needs: [detect-changes, build]
     if: needs.detect-changes.outputs.has-changes == 'true'
     runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      id-token: write # assume the OIDC apply role
+      contents: read
     strategy:
       fail-fast: false
       matrix:
         lambda: ${{ fromJson(needs.detect-changes.outputs.lambdas) }}
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_REGION: us-east-2
     steps:
       - name: Compute artifact name
         id: artifact
@@ -109,6 +109,12 @@ jobs:
         with:
           name: ${{ steps.artifact.outputs.name }}
           path: ${{ matrix.lambda }}
+
+      - name: Configure AWS credentials (write apply role via OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::489881683177:role/branch-ci-apply
+          aws-region: us-east-2
 
       - name: Deploy lambda
         id: deploy

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -90,6 +90,9 @@ jobs:
         directory: ${{ fromJson(needs.detect-changes.outputs.terraform-dirs) }}
       fail-fast: false
     environment: production
+    permissions:
+      id-token: write # assume the OIDC apply role
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -105,11 +108,10 @@ jobs:
           tfenv install
           terraform version
 
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials (write apply role via OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::489881683177:role/branch-ci-apply
           aws-region: us-east-2
 
       - name: Terraform Init

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -157,6 +157,10 @@ jobs:
       needs.detect-changes.outputs.terraform-dirs != '' &&
       needs.detect-changes.outputs.terraform-dirs != '[]'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # assume the OIDC plan role
+      contents: read
+      pull-requests: write # post plan comments
     strategy:
       matrix:
         directory: ${{ fromJson(needs.detect-changes.outputs.terraform-dirs) }}
@@ -179,11 +183,10 @@ jobs:
           tfenv install
           terraform version
 
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials (read-only plan role via OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::489881683177:role/branch-ci-plan
           aws-region: us-east-2
 
       - name: Terraform Init


### PR DESCRIPTION
## What

Points the three AWS-touching workflows at the OIDC roles from the roles PR, dropping the static `AWS_ACCESS_KEY_ID/SECRET`:

| Workflow | Role | Trigger scope |
|---|---|---|
| `terraform-plan` | `branch-ci-plan` (read-only) | any PR / branch |
| `terraform-apply` | `branch-ci-apply` (write) | `environment: production` |
| `lambda-deploy` | `branch-ci-apply` (write) | now `environment: production` |

Adds `permissions: id-token: write` to those jobs.

## ⚠️ Merge AFTER the roles PR is applied

`feat/ci-oidc-scoped-roles` must be merged **and applied** first — otherwise plan/apply can't assume roles that don't exist. Merging this (workflow-only) change does **not** trigger `terraform-apply`, so there's no deadlock; it just won't work until the roles are live.

Post-cutover: remove the unused `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` secrets (and drop them from the `infrastructure/github` Infisical→secrets sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)