### PR TITLE
feat: filled deploy status bar + Slack bot-message purge workflow

### DIFF
--- a/.github/actions/slack-deploy/action.yml
+++ b/.github/actions/slack-deploy/action.yml
@@ -167,9 +167,27 @@ runs:
             return `<${commitUrl}|\`${shortSha}\`>`;
           }
 
-          function bar(d, t) {
+          // A filled progress bar with a leading status icon. The icon is
+          // `:loading:` while in progress and flips to a check / cross when the
+          // deploy finishes. `d`/`t` are still shown as x/y alongside a percent.
+          function bar(d, t, state = 'progress') {
+            const width = 24;
             const filled = Math.max(0, Math.min(t, d));
-            return '`[' + '▰'.repeat(filled) + '▱'.repeat(Math.max(0, t - filled)) + `] ${filled}/${t}\``;
+            const ratio = t > 0 ? filled / t : 0;
+            const pct = Math.round(ratio * 100);
+            const exact = ratio * width;
+            const fullCells = Math.floor(exact);
+            const partials = ['', '▏', '▎', '▍', '▌', '▋', '▊', '▉'];
+            const partIdx = fullCells < width ? Math.floor((exact - fullCells) * 8) : 0;
+            const partCell = partIdx > 0 ? partials[partIdx] : '';
+            const emptyCells = Math.max(0, width - fullCells - (partCell ? 1 : 0));
+            const track = '█'.repeat(fullCells) + partCell + '░'.repeat(emptyCells);
+            const icon = state === 'complete'
+              ? ':heavy_check_mark:'
+              : state === 'fail'
+                ? ':heavy_multiplication_x:'
+                : ':loading:';
+            return `${icon} \`[${track}]\` ${pct}% (${filled}/${t})`;
           }
 
           function logBlock(text) {
@@ -181,19 +199,19 @@ runs:
 
           // Root "Deploying" message. Header is FIXED (never changes) — only the
           // status bar advances. Completion/failure are told in thread replies.
-          async function mainBlocks(d) {
+          async function mainBlocks(d, state = 'progress') {
             const prLinks = await resolvePrLinks();
             return [
               { type: 'header', text: { type: 'plain_text', text: `:ship: :evergreen_tree:  Deploying ${component} — ${shortSha}`, emoji: true } },
-              { type: 'section', text: { type: 'mrkdwn', text: bar(d, total) } },
+              { type: 'section', text: { type: 'mrkdwn', text: bar(d, total, state) } },
               { type: 'context', elements: [
                 { type: 'mrkdwn', text: `Deployed by ${authorMention}  |  ${prLinks}  |  <${runUrl}|Workflow run>` },
               ] },
             ];
           }
 
-          async function updateBar(d) {
-            if (ts) await slack('chat.update', { channel, ts, text: `Deploying ${component}`, blocks: await mainBlocks(d) });
+          async function updateBar(d, state = 'progress') {
+            if (ts) await slack('chat.update', { channel, ts, text: `Deploying ${component}`, blocks: await mainBlocks(d, state) });
           }
 
           async function threadStep(idx, name, ok, log) {
@@ -210,7 +228,7 @@ runs:
               channel, thread_ts: ts, text: 'Deploy complete',
               blocks: [{ type: 'section', text: { type: 'mrkdwn', text: 'Deploy complete :white_check_mark: :freaky-pumpkin:' } }],
             });
-            await updateBar(total);
+            await updateBar(total, 'complete');
           }
 
           async function threadFail(name, log, atBar) {
@@ -224,7 +242,7 @@ runs:
             const body = { channel, text: `${component} deploy failed ${pings}`, blocks };
             if (ts) await slack('chat.postMessage', { ...body, thread_ts: ts, reply_broadcast: true });
             else await slack('chat.postMessage', body);
-            await updateBar(atBar);
+            await updateBar(atBar, 'fail');
           }
 
           // Live progress: count completed matrix legs of this run for the bar.

--- a/.github/workflows/slack-purge-bot-messages.yml
+++ b/.github/workflows/slack-purge-bot-messages.yml
@@ -1,0 +1,134 @@
+name: Slack Purge Bot Messages
+
+# One-off manual cleanup: deletes messages posted by the deploy bot in a Slack
+# channel (default: #proj-branch-deployments). A bot token's chat.delete can
+# only remove messages the bot itself authored, so this only touches bot posts.
+#
+# Safety: defaults to a dry run. To actually delete, set dry_run=false AND type
+# DELETE into the confirm box.
+
+on:
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: 'Slack channel id to purge'
+        required: true
+        default: C0BE7FYMHFF
+      dry_run:
+        description: 'Dry run (only count, delete nothing)'
+        type: boolean
+        required: true
+        default: true
+      confirm:
+        description: 'Type DELETE to confirm a real purge (ignored on dry run)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  purge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete bot messages
+        uses: actions/github-script@v7
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          CHANNEL: ${{ inputs.channel }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          CONFIRM: ${{ inputs.confirm }}
+        with:
+          script: |
+            const token = process.env.SLACK_BOT_TOKEN;
+            const channel = process.env.CHANNEL;
+            const dryRun = process.env.DRY_RUN !== 'false';
+
+            if (!dryRun && process.env.CONFIRM !== 'DELETE') {
+              core.setFailed('Refusing to purge: set dry_run=false AND type DELETE in confirm.');
+              return;
+            }
+
+            const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+
+            async function slack(method, body) {
+              for (let attempt = 0; attempt < 6; attempt++) {
+                const resp = await fetch(`https://slack.com/api/${method}`, {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+                  body: JSON.stringify(body),
+                });
+                // Respect Slack rate limits (HTTP 429 + Retry-After).
+                if (resp.status === 429) {
+                  const wait = (parseInt(resp.headers.get('retry-after') || '1', 10) || 1) * 1000;
+                  console.log(`Rate limited on ${method}; waiting ${wait}ms`);
+                  await sleep(wait);
+                  continue;
+                }
+                const data = await resp.json();
+                if (!data.ok && data.error === 'ratelimited') { await sleep(1000); continue; }
+                return data;
+              }
+              return { ok: false, error: 'rate_limit_retries_exhausted' };
+            }
+
+            // Gather every timestamp: top-level messages + their thread replies.
+            async function collectTimestamps() {
+              const tsList = [];
+              let cursor;
+              do {
+                const page = await slack('conversations.history', {
+                  channel, limit: 200, ...(cursor ? { cursor } : {}),
+                });
+                if (!page.ok) {
+                  core.setFailed(`conversations.history failed: ${page.error}`);
+                  return null;
+                }
+                for (const msg of page.messages || []) {
+                  tsList.push(msg.ts);
+                  // Thread parents report reply_count; pull replies so we delete them too.
+                  if (msg.reply_count > 0 || msg.thread_ts === msg.ts) {
+                    let rCursor;
+                    do {
+                      const replies = await slack('conversations.replies', {
+                        channel, ts: msg.ts, limit: 200, ...(rCursor ? { cursor: rCursor } : {}),
+                      });
+                      if (!replies.ok) { console.log(`replies failed for ${msg.ts}: ${replies.error}`); break; }
+                      for (const r of replies.messages || []) {
+                        if (r.ts !== msg.ts) tsList.push(r.ts);
+                      }
+                      rCursor = replies.response_metadata && replies.response_metadata.next_cursor;
+                    } while (rCursor);
+                  }
+                }
+                cursor = page.response_metadata && page.response_metadata.next_cursor;
+              } while (cursor);
+              return tsList;
+            }
+
+            const timestamps = await collectTimestamps();
+            if (timestamps === null) return;
+            console.log(`Found ${timestamps.length} message(s) in ${channel}.`);
+
+            if (dryRun) {
+              console.log('Dry run — nothing deleted. Re-run with dry_run=false and confirm=DELETE to purge.');
+              return;
+            }
+
+            // Delete newest-first isn't required, but process oldest-first so parents
+            // outlast replies. Non-bot messages return cant_delete_message — skipped.
+            let deleted = 0, skipped = 0;
+            for (const ts of timestamps.reverse()) {
+              const res = await slack('chat.delete', { channel, ts });
+              if (res.ok) {
+                deleted++;
+              } else if (['message_not_found', 'cant_delete_message'].includes(res.error)) {
+                skipped++;
+              } else {
+                console.log(`Delete ${ts} failed: ${res.error}`);
+                skipped++;
+              }
+              // chat.delete is Tier 3 (~50/min); ~1.2s keeps us comfortably under.
+              await sleep(1200);
+            }
+            console.log(`Done. Deleted ${deleted}, skipped ${skipped}.`);


### PR DESCRIPTION
## Summary
- Redesign the Slack deploy status bar (`.github/actions/slack-deploy/action.yml`) into a solid filled bar using full + partial block cells, with a percentage alongside the existing `x/y` count.
- Add a leading status icon that flips from `:loading:` while deploying to `:heavy_check_mark:` on success / `:heavy_multiplication_x:` on failure (threaded through `bar` → `mainBlocks` → `updateBar`).
- Add `.github/workflows/slack-purge-bot-messages.yml`: a one-off `workflow_dispatch` job to delete the deploy bot's messages (and thread replies) in a Slack channel.

## Notes
- The purge workflow defaults to a **dry run**; a real purge requires `dry_run=false` **and** typing `DELETE` in the confirm box.
- A bot token's `chat.delete` can only remove messages the bot itself authored, so human messages are skipped.
- Requires the bot to be in the channel and the token to have `channels:history` (or `groups:history`) + `chat:write`.
- `:loading:` is a custom Slack emoji — it must exist in the workspace, otherwise it renders as literal text.

## Test plan
- [ ] Trigger a deploy and confirm the bar renders filled with `:loading:` and advances.
- [ ] Confirm the icon becomes `:heavy_check_mark:` on success and `:heavy_multiplication_x:` on failure.
- [ ] Run the purge workflow as a dry run and verify the counted total looks right.
- [ ] Run a real purge (dry_run=false, confirm=DELETE) in a test/low-stakes channel and verify bot messages are removed.

Made with [Cursor](https://cursor.com)