### PR TITLE
fix: public/ assets 404 in PR previews (basePath) + lint guard

### DIFF
--- a/apps/frontend/eslint.config.mjs
+++ b/apps/frontend/eslint.config.mjs
@@ -20,6 +20,23 @@ const eslintConfig = [
       "next-env.d.ts",
     ],
   },
+  {
+    // public/ assets referenced by a raw leading-slash src (e.g.
+    // <Image src="/branch-logo.png" />) are NOT prefixed with Next's basePath,
+    // so they 404 in ephemeral PR preview environments served under /pr-<N>/.
+    // Force them through assetPath() from @/lib/asset (a no-op in prod).
+    files: ["src/**/*.{ts,tsx,js,jsx}"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "JSXAttribute[name.name='src'] > Literal[value=/^\\u002f/]",
+          message:
+            "Reference public/ assets via assetPath(\"/...\") from @/lib/asset — a raw \"/foo.png\" src is not prefixed with basePath and 404s in preview environments (/pr-<N>/).",
+        },
+      ],
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/apps/frontend/next.config.ts
+++ b/apps/frontend/next.config.ts
@@ -15,9 +15,13 @@ const nextConfig: NextConfig = {
   output: 'export',
   trailingSlash: true, // emit /route/index.html — clean S3 key mapping
   images: { unoptimized: true }, // no server image optimizer in export
-  // basePath already prefixes emitted asset URLs (/pr-<N>/_next/...), so no
-  // separate assetPrefix is needed.
-  ...(previewBasePath ? { basePath: previewBasePath } : {}),
+  // basePath already prefixes emitted /_next/* asset URLs, but Next does NOT
+  // prefix public/ assets referenced by string src (e.g. "/branch-logo.png").
+  // Expose the base path as NEXT_PUBLIC_BASE_PATH so components can prefix those
+  // themselves via lib/asset.ts (empty string in prod → unchanged).
+  ...(previewBasePath
+    ? { basePath: previewBasePath, env: { NEXT_PUBLIC_BASE_PATH: previewBasePath } }
+    : {}),
 };
 
 export default nextConfig;

--- a/apps/frontend/src/app/components/Header.tsx
+++ b/apps/frontend/src/app/components/Header.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Image from "next/image";
+import { assetPath } from "@/lib/asset";
 
 interface HeaderProps {
   text?: string;
@@ -25,7 +26,7 @@ const Header: React.FC<HeaderProps> = ({
         {icon || (
           // Default Profile Icon matching Figma
           <div className="h-8 w-8 rounded-full border border-gray-300 flex items-center justify-center">
-             <Image src="/profile-icon.svg" alt="Profile Icon" width={24} height={24} />
+             <Image src={assetPath("/profile-icon.svg")} alt="Profile Icon" width={24} height={24} />
           </div>
         )}
       </div>

--- a/apps/frontend/src/app/components/Navbar.tsx
+++ b/apps/frontend/src/app/components/Navbar.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { PT_Sans } from "next/font/google";
 import { useAuth } from "@/context/AuthContext";
+import { assetPath } from "@/lib/asset";
 
 const ptSans = PT_Sans({ subsets: ["latin"], weight: ["400", "700"] });
 
@@ -74,7 +75,7 @@ export const NavBar: React.FC<{ role?: UserRole; activePath?: string }> = ({
       {/* Background Image Layer */}
       <div style={{ position: "absolute", inset: 0, zIndex: 0 }}>
         <Image
-          src="/leaves-bg.png"
+          src={assetPath("/leaves-bg.png")}
           alt=""
           fill
           style={{ objectFit: "cover" }}
@@ -90,7 +91,7 @@ export const NavBar: React.FC<{ role?: UserRole; activePath?: string }> = ({
         flexDirection: "column",
         alignItems: "center",
       }}>
-        <Image src="/branch-logo.png" alt="Branch" width={75} height={75} />
+        <Image src={assetPath("/branch-logo.png")} alt="Branch" width={75} height={75} />
         <div style={{
           color: COLORS.white,
           fontSize: 18,

--- a/apps/frontend/src/lib/asset.ts
+++ b/apps/frontend/src/lib/asset.ts
@@ -1,0 +1,12 @@
+// Resolve a public/ asset path so it works under a preview basePath.
+//
+// Next.js prefixes /_next/* build assets with `basePath`, but NOT public/
+// assets referenced by string src (e.g. <Image src="/branch-logo.png" />).
+// Under an ephemeral PR preview served at /pr-<N>/ those would 404 (the file
+// actually lives at /pr-<N>/branch-logo.png). NEXT_PUBLIC_BASE_PATH is set to
+// "/pr-<N>" only for preview builds (see next.config.ts); it's empty in prod,
+// so this is a no-op there.
+export function assetPath(path: string): string {
+  const base = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+  return `${base}${path}`;
+}


### PR DESCRIPTION
## Bug
Images (sidebar Branch logo, leaves background, profile icon) don't load in ephemeral PR preview environments.

**Cause:** previews are served under `/pr-<N>/` with Next `basePath=/pr-<N>`. Next prefixes `/_next/*` build assets with basePath but **not** `public/` assets referenced by a string `src` (`<Image src="/branch-logo.png" />`). So the browser requests `/branch-logo.png` (root of the shared CloudFront) → 404; the file actually lives at `/pr-<N>/branch-logo.png`.

## Fix
- `next.config.ts`: expose `NEXT_PUBLIC_BASE_PATH` (= `/pr-<N>`) in preview builds only.
- `src/lib/asset.ts`: `assetPath("/foo.png")` prefixes it with that base path — **no-op in prod** (empty var).
- Route the 3 existing public-asset `<Image src>`s through `assetPath()`.

## Lint guard (requested)
Added an ESLint `no-restricted-syntax` rule that flags any raw leading-slash `src` string literal, pointing devs at `assetPath()`:

> Reference public/ assets via assetPath("/...") from @/lib/asset — a raw "/foo.png" src is not prefixed with basePath and 404s in preview environments (/pr-<N>/).

Verified: fixed files pass, a raw `<Image src="/x.png">` is flagged, and 0 violations exist across `src/`.

## Notes
Draft — needs a preview to visually confirm. After merge to main, the throwaway PR #275 (rebased on main) should render the logo correctly under its preview URL.

Prod deploy path is unchanged (`NEXT_PUBLIC_BASE_PATH` is empty → `assetPath` returns the path as-is).