### PR TITLE
247 missing crud endpoints in expenditures

### DIFF
--- a/apps/backend/lambdas/expenditures/README.md
+++ b/apps/backend/lambdas/expenditures/README.md
@@ -9,8 +9,6 @@ Lambda for tracking project expenditures.
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | /health | Health check |
-| GET | /expenditures |  |
-| POST | /expenditures |  |
 
 ## Setup
 

--- a/apps/backend/lambdas/expenditures/README.md
+++ b/apps/backend/lambdas/expenditures/README.md
@@ -9,6 +9,10 @@ Lambda for tracking project expenditures.
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | /health | Health check |
+| GET | /expenditures |  |
+| POST | /expenditures |  |
+| GET | /expenditures/{id} |  |
+| DELETE | /expenditures/{id} |  |
 
 ## Setup
 

--- a/apps/backend/lambdas/expenditures/handler.ts
+++ b/apps/backend/lambdas/expenditures/handler.ts
@@ -184,10 +184,25 @@ export const handler = async (event: any): Promise<APIGatewayProxyResult> => {
       if (!authContext.isAuthenticated || !authContext.user) {
         return json(401, { message: 'Authentication required' });
       }
+
+      const { user } = authContext;
       
       const expenditure = await db.selectFrom("branch.expenditures").where("expenditure_id", "=", Number(id)).selectAll().executeTakeFirst();
       if (!expenditure) return json(404, { message: 'Expenditure not found' });
 
+      if (!user.isAdmin) {
+        const membership = await db
+          .selectFrom('branch.project_memberships')
+          .where('project_id', '=', expenditure.project_id)
+          .where('user_id', '=', user.userId!)
+          .select('role')
+          .executeTakeFirst();
+
+        if (!membership) {
+          return json(403, { message: 'Unable to view this expenditure' });
+        }
+      }
+      
       return json(200, { 
         ok: true, 
         route: 'GET /expenditures/{id}', 

--- a/apps/backend/lambdas/expenditures/handler.ts
+++ b/apps/backend/lambdas/expenditures/handler.ts
@@ -169,7 +169,90 @@ export const handler = async (event: any): Promise<APIGatewayProxyResult> => {
         },
       });
     }
-    // <<< ROUTES-END
+    
+    // GET /expenditures/{id}
+    if (/^\/[^\/]+$/.test(normalizedPath) && method === 'GET') {
+      const id = normalizedPath.split('/')[1];
+      if (!id) return json(400, { message: 'id is required' });
+      
+      if (!id || !/^\d+$/.test(id)) {
+        return json(400, { message: 'id must be a positive integer' });
+      }
+    
+
+      const authContext = await authenticateRequest(event);
+      if (!authContext.isAuthenticated || !authContext.user) {
+        return json(401, { message: 'Authentication required' });
+      }
+      
+      const expenditure = await db.selectFrom("branch.expenditures").where("expenditure_id", "=", Number(id)).selectAll().executeTakeFirst();
+      if (!expenditure) return json(404, { message: 'Expenditure not found' });
+
+      return json(200, { 
+        ok: true, 
+        route: 'GET /expenditures/{id}', 
+        pathParams: { id }, 
+        body: { 
+          expenditureId: expenditure.expenditure_id,
+          projectId: expenditure.project_id,
+          enteredBy: expenditure.entered_by,
+          amount: expenditure.amount,
+          category: expenditure.category,
+          description: expenditure.description,
+          status: expenditure.status,
+          receiptUrl: expenditure.receipt_url,
+          spent_on: expenditure.spent_on,
+          createdAt: expenditure.created_at,
+        } 
+      });
+    }
+    
+    // DELETE /expenditures/{id}
+    if (/^\/[^\/]+$/.test(normalizedPath) && method === 'DELETE') {
+      const id = normalizedPath.split('/')[1];
+      if (!id) return json(400, { message: 'id is required' });
+      if (!id || !/^\d+$/.test(id)) {
+        return json(400, { message: 'id must be a positive integer' });
+      }
+
+      const authContext = await authenticateRequest(event);
+      if (!authContext.isAuthenticated || !authContext.user) {
+        return json(401, { message: 'Authentication required' });
+      }
+      const { user } = authContext;
+
+      const expenditure = await db
+        .selectFrom('branch.expenditures')
+        .where('expenditure_id', '=', Number(id))
+        .selectAll()
+        .executeTakeFirst();
+
+    if (!expenditure) {
+      return json(404, { message: 'Expenditure not found' });
+    }
+
+    // (mirrors POST endpoint) Authorize: must be global admin, or PI/Accountant/Admin on this expenditure's project
+    if (!user.isAdmin) {
+      const membership = await db
+        .selectFrom('branch.project_memberships')
+        .where('project_id', '=', expenditure.project_id)
+        .where('user_id', '=', user.userId!)
+        .select('role')
+        .executeTakeFirst();
+
+      if (!membership || !['PI', 'Accountant', 'Admin'].includes(membership.role)) {
+        return json(403, { message: 'Unable to delete this expenditure' });
+      }
+    }
+      
+      const deleted = await db.deleteFrom('branch.expenditures').where('expenditure_id', '=', Number(id)).execute();
+    
+      if (!deleted[0] || deleted[0].numDeletedRows === 0n) {
+        return json(404, { message: 'Expenditure not found' });
+      }
+
+      return json(200, { ok: true, route: 'DELETE /expenditures/{id}', pathParams: { id } });
+    }
 
     return json(404, { message: 'Not Found', path: normalizedPath, method });
   } catch (err) {

--- a/apps/backend/lambdas/expenditures/handler.ts
+++ b/apps/backend/lambdas/expenditures/handler.ts
@@ -227,23 +227,23 @@ export const handler = async (event: any): Promise<APIGatewayProxyResult> => {
         .selectAll()
         .executeTakeFirst();
 
-    if (!expenditure) {
-      return json(404, { message: 'Expenditure not found' });
-    }
-
-    // (mirrors POST endpoint) Authorize: must be global admin, or PI/Accountant/Admin on this expenditure's project
-    if (!user.isAdmin) {
-      const membership = await db
-        .selectFrom('branch.project_memberships')
-        .where('project_id', '=', expenditure.project_id)
-        .where('user_id', '=', user.userId!)
-        .select('role')
-        .executeTakeFirst();
-
-      if (!membership || !['PI', 'Accountant', 'Admin'].includes(membership.role)) {
-        return json(403, { message: 'Unable to delete this expenditure' });
+      if (!expenditure) {
+        return json(404, { message: 'Expenditure not found' });
       }
-    }
+
+      // (mirrors POST endpoint) Authorize: must be global admin, or PI/Accountant/Admin on this expenditure's project
+      if (!user.isAdmin) {
+        const membership = await db
+          .selectFrom('branch.project_memberships')
+          .where('project_id', '=', expenditure.project_id)
+          .where('user_id', '=', user.userId!)
+          .select('role')
+          .executeTakeFirst();
+
+        if (!membership || !['PI', 'Accountant', 'Admin'].includes(membership.role)) {
+          return json(403, { message: 'Unable to delete this expenditure' });
+        }
+      }
       
       const deleted = await db.deleteFrom('branch.expenditures').where('expenditure_id', '=', Number(id)).execute();
     
@@ -253,6 +253,7 @@ export const handler = async (event: any): Promise<APIGatewayProxyResult> => {
 
       return json(200, { ok: true, route: 'DELETE /expenditures/{id}', pathParams: { id } });
     }
+    // <<< ROUTES-END
 
     return json(404, { message: 'Not Found', path: normalizedPath, method });
   } catch (err) {

--- a/apps/backend/lambdas/expenditures/openapi.yaml
+++ b/apps/backend/lambdas/expenditures/openapi.yaml
@@ -101,3 +101,27 @@ paths:
       responses:
         '201':
           description: Success
+
+  /expenditures/{id}:
+    get:
+      summary: GET /expenditures/{id}
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+    delete:
+      summary: DELETE /expenditures/{id}
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK

--- a/apps/backend/lambdas/expenditures/test/expenditures.e2e.test.ts
+++ b/apps/backend/lambdas/expenditures/test/expenditures.e2e.test.ts
@@ -86,6 +86,48 @@ const staffUser = {
   },
 };
 
+// Builds a Lambda event for GET or DELETE /expenditures/{id}
+function idRequestEvent(method: 'GET' | 'DELETE', id: string | number) {
+  return {
+    rawPath: `/expenditures/${id}`,
+    requestContext: { http: { method } },
+    headers: { Authorization: 'Bearer fake-token' },
+  };
+}
+
+// Looks up a real expenditure_id belonging to the given project from the
+// freshly-seeded DB, so tests don't hardcode ids that could drift if the
+// seed data changes. Throws error if none found
+async function firstExpenditureId(projectId: number): Promise<number> {
+  const client = await pool.connect();
+  try {
+    const result = await client.query(
+      'SELECT expenditure_id FROM branch.expenditures WHERE project_id = $1 ORDER BY expenditure_id LIMIT 1',
+      [projectId]
+    );
+    if (result.rows.length === 0) {
+      throw new Error(`No seeded expenditure found for project_id=${projectId}`);
+    }
+    return result.rows[0].expenditure_id;
+  } finally {
+    client.release();
+  }
+}
+
+// Directly queries the DB to confirm whether a row still exists
+async function expenditureExists(id: number): Promise<boolean> {
+  const client = await pool.connect();
+  try {
+    const result = await client.query(
+      'SELECT 1 FROM branch.expenditures WHERE expenditure_id = $1',
+      [id]
+    );
+    return (result.rowCount ?? 0) > 0;
+  } finally {
+    client.release();
+  }
+}
+
 describe('Expenditures integration tests', () => {
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -400,6 +442,144 @@ describe('Expenditures integration tests', () => {
       mockAuthenticateRequest.mockResolvedValue(adminUser);
       const res = await handler(getEvent('/', { projectId: 'abc' }));
       expect(res.statusCode).toBe(400);
+    });
+  });
+
+  
+  describe('GET /expenditures/{id}', () => {
+    test('401: unauthenticated request is rejected', async () => {
+      mockAuthenticateRequest.mockResolvedValue({ isAuthenticated: false });
+      const id = await firstExpenditureId(1);
+
+      const res = await handler(idRequestEvent('GET', id));
+      expect(res.statusCode).toBe(401);
+    });
+
+    test('400: non-numeric id returns 400', async () => {
+      const res = await handler(idRequestEvent('GET', 'not-a-number'));
+      expect(res.statusCode).toBe(400);
+    });
+
+    test('404: unknown id returns 404', async () => {
+      const res = await handler(idRequestEvent('GET', 999999));
+      expect(res.statusCode).toBe(404);
+      expect(JSON.parse(res.body).message).toBe('Expenditure not found');
+    });
+
+    test('200: admin can fetch an expenditure by id', async () => {
+      const id = await firstExpenditureId(1);
+      const res = await handler(idRequestEvent('GET', id));
+
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body.body.expenditureId).toBe(id);
+      expect(body.body.projectId).toBe(1);
+    });
+
+    test('200: staff with no membership on the project can still read it', async () => {
+      mockAuthenticateRequest.mockResolvedValue(staffUser);
+      const id = await firstExpenditureId(1); // staffUser has no role on project 1
+
+      const res = await handler(idRequestEvent('GET', id));
+      expect(res.statusCode).toBe(200);
+    });
+  });
+
+  describe('DELETE /expenditures/{id}', () => {
+    test('401: unauthenticated request is rejected', async () => {
+      mockAuthenticateRequest.mockResolvedValue({ isAuthenticated: false });
+      const id = await firstExpenditureId(1);
+
+      const res = await handler(idRequestEvent('DELETE', id));
+      expect(res.statusCode).toBe(401);
+      expect(await expenditureExists(id)).toBe(true);
+    });
+
+    test('400: non-numeric id returns 400', async () => {
+      const res = await handler(idRequestEvent('DELETE', 'abc'));
+      expect(res.statusCode).toBe(400);
+    });
+
+    test('404: unknown id returns 404', async () => {
+      const res = await handler(idRequestEvent('DELETE', 999999));
+      expect(res.statusCode).toBe(404);
+    });
+
+    test('403: Staff cannot delete an expenditure on a project they have no role on', async () => {
+      mockAuthenticateRequest.mockResolvedValue(staffUser);
+      const id = await firstExpenditureId(1); // staffUser has no membership on project 1
+
+      const res = await handler(idRequestEvent('DELETE', id));
+      expect(res.statusCode).toBe(403);
+      expect(await expenditureExists(id)).toBe(true);
+    });
+
+    test('403: Staff role on their own project is still not sufficient to delete', async () => {
+      mockAuthenticateRequest.mockResolvedValue(staffUser);
+      const id = await firstExpenditureId(2); // staffUser is Staff on project 2
+
+      const res = await handler(idRequestEvent('DELETE', id));
+      expect(res.statusCode).toBe(403);
+      expect(await expenditureExists(id)).toBe(true);
+    });
+
+    test('200: PI can delete an expenditure on their own project', async () => {
+      mockAuthenticateRequest.mockResolvedValue(piUser);
+      const id = await firstExpenditureId(1);
+
+      const res = await handler(idRequestEvent('DELETE', id));
+      expect(res.statusCode).toBe(200);
+      expect(await expenditureExists(id)).toBe(false);
+    });
+
+    test('200: Accountant can delete an expenditure on their own project', async () => {
+      mockAuthenticateRequest.mockResolvedValue(accountantUser);
+      const id = await firstExpenditureId(1);
+
+      const res = await handler(idRequestEvent('DELETE', id));
+      expect(res.statusCode).toBe(200);
+      expect(await expenditureExists(id)).toBe(false);
+    });
+
+    test('200: admin can delete an expenditure on any project', async () => {
+      const id = await firstExpenditureId(2);
+
+      const res = await handler(idRequestEvent('DELETE', id));
+      expect(res.statusCode).toBe(200);
+      expect(await expenditureExists(id)).toBe(false);
+    });
+
+    test('404: deleting the same expenditure twice returns 404 the second time', async () => {
+      const id = await firstExpenditureId(1);
+
+      const first = await handler(idRequestEvent('DELETE', id));
+      expect(first.statusCode).toBe(200);
+
+      const second = await handler(idRequestEvent('DELETE', id));
+      expect(second.statusCode).toBe(404);
+    });
+
+    test('deleting one expenditure does not affect other rows', async () => {
+      const client = await pool.connect();
+      let totalBefore: number;
+      try {
+        const result = await client.query('SELECT COUNT(*)::int AS count FROM branch.expenditures');
+        totalBefore = result.rows[0].count;
+      } finally {
+        client.release();
+      }
+
+      const id = await firstExpenditureId(1);
+      const res = await handler(idRequestEvent('DELETE', id));
+      expect(res.statusCode).toBe(200);
+
+      const client2 = await pool.connect();
+      try {
+        const result = await client2.query('SELECT COUNT(*)::int AS count FROM branch.expenditures');
+        expect(result.rows[0].count).toBe(totalBefore - 1);
+      } finally {
+        client2.release();
+      }
     });
   });
 });

--- a/apps/backend/lambdas/expenditures/test/expenditures.e2e.test.ts
+++ b/apps/backend/lambdas/expenditures/test/expenditures.e2e.test.ts
@@ -476,10 +476,18 @@ describe('Expenditures integration tests', () => {
       expect(body.body.projectId).toBe(1);
     });
 
-    test('200: staff with no membership on the project can still read it', async () => {
+    test('403: staff with no membership on the project cannot read it', async () => {
       mockAuthenticateRequest.mockResolvedValue(staffUser);
       const id = await firstExpenditureId(1); // staffUser has no role on project 1
-
+    
+      const res = await handler(idRequestEvent('GET', id));
+      expect(res.statusCode).toBe(403);
+    });
+    
+    test('200: staff can read an expenditure on a project they have a role on', async () => {
+      mockAuthenticateRequest.mockResolvedValue(staffUser);
+      const id = await firstExpenditureId(2); // staffUser is Staff on project 2
+    
       const res = await handler(idRequestEvent('GET', id));
       expect(res.statusCode).toBe(200);
     });

--- a/apps/backend/lambdas/expenditures/test/expenditures.unit.test.ts
+++ b/apps/backend/lambdas/expenditures/test/expenditures.unit.test.ts
@@ -42,6 +42,71 @@ function getEvent(queryStringParameters?: Record<string, string>) {
   };
 }
 
+// Builds a Lambda event for GET or DELETE /expenditures/{id}
+function idEvent(method: 'GET' | 'DELETE', id: string) {
+  return {
+    rawPath: `/expenditures/${id}`,
+    requestContext: { http: { method } },
+    headers: { Authorization: 'Bearer fake-token' },
+  };
+}
+
+const staffAuthContext = {
+  isAuthenticated: true as const,
+  user: { cognitoSub: 'staff-sub', userId: 2, email: 'staff@example.com', isAdmin: false },
+};
+
+const piAuthContext = {
+  isAuthenticated: true as const,
+  user: { cognitoSub: 'pi-sub', userId: 3, email: 'pi@example.com', isAdmin: false },
+};
+
+const fakeExpenditure = {
+  expenditure_id: 5,
+  project_id: 1,
+  entered_by: 1,
+  amount: '1200',
+  category: 'Travel',
+  description: 'Flight',
+  status: 'pending',
+  receipt_url: null,
+  spent_on: new Date('2025-06-01'),
+  created_at: new Date('2025-06-01'),
+};
+
+// Mocks the query chain used by the handler to fetch a single expenditure
+function mockSelectExpenditure(result: any) {
+  return {
+    where: jest.fn().mockReturnValue({
+      selectAll: jest.fn().mockReturnValue({
+        executeTakeFirst: jest.fn().mockReturnValue(result),
+      }),
+    }),
+  };
+}
+
+// Mocks the query chain used by the handler to check project membership
+function mockMembership(result: any) {
+  return {
+    where: jest.fn().mockReturnValue({
+      where: jest.fn().mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          executeTakeFirst: jest.fn().mockReturnValue(result),
+        }),
+      }),
+    }),
+  };
+}
+
+// Mocks the query chain used by the handler to delete an expenditure
+function mockDelete(numDeletedRows: bigint) {
+  return {
+    where: jest.fn().mockReturnValue({
+      execute: jest.fn().mockReturnValue([{ numDeletedRows }]),
+    }),
+  };
+}
+
 // Default authenticated admin user
 const adminAuthContext = {
   isAuthenticated: true as const,
@@ -587,6 +652,214 @@ describe('POST /expenditures unit tests', () => {
     test('400: invalid projectId returns 400', async () => {
       const res = await handler(getEvent({ projectId: '-5' }));
       expect(res.statusCode).toBe(400);
+    });
+  });
+});
+
+
+describe('GET /expenditures/{id} unit tests', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuthenticateRequest.mockResolvedValue(adminAuthContext);
+  });
+
+  describe('Validation', () => {
+    test('400: non-numeric id', async () => {
+      const res = await handler(idEvent('GET', 'abc'));
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res.body).message).toContain('positive integer');
+    });
+
+    test('400: negative id', async () => {
+      const res = await handler(idEvent('GET', '-5'));
+      expect(res.statusCode).toBe(400);
+    });
+
+    test('400: decimal id', async () => {
+      const res = await handler(idEvent('GET', '5.5'));
+      expect(res.statusCode).toBe(400);
+    });
+  });
+
+  describe('Authentication', () => {
+    test('401: unauthenticated request is rejected', async () => {
+      mockAuthenticateRequest.mockResolvedValue({ isAuthenticated: false });
+      const res = await handler(idEvent('GET', '5'));
+      expect(res.statusCode).toBe(401);
+      expect(JSON.parse(res.body).message).toBe('Authentication required');
+    });
+  });
+
+  describe('Not found', () => {
+    test('404: expenditure does not exist', async () => {
+      mockDb.selectFrom.mockReturnValue(mockSelectExpenditure(null));
+      const res = await handler(idEvent('GET', '999'));
+      expect(res.statusCode).toBe(404);
+      expect(JSON.parse(res.body).message).toBe('Expenditure not found');
+    });
+  });
+
+  describe('Success cases', () => {
+    test('200: admin can read any expenditure', async () => {
+      mockDb.selectFrom.mockReturnValue(mockSelectExpenditure(fakeExpenditure));
+      const res = await handler(idEvent('GET', '5'));
+
+      expect(res.statusCode).toBe(200);
+      const json = JSON.parse(res.body);
+      expect(json.ok).toBe(true);
+      expect(json.route).toBe('GET /expenditures/{id}');
+      expect(json.body.expenditureId).toBe(5);
+      expect(json.body.projectId).toBe(1);
+      expect(json.body.amount).toBe('1200');
+    });
+
+    test('200: authenticated non-admin with no project membership can still read (read is not project-scoped)', async () => {
+      mockAuthenticateRequest.mockResolvedValue(staffAuthContext);
+      mockDb.selectFrom.mockReturnValue(mockSelectExpenditure(fakeExpenditure));
+
+      const res = await handler(idEvent('GET', '5'));
+      expect(res.statusCode).toBe(200);
+    });
+
+    test('response has correct HTTP headers', async () => {
+      mockDb.selectFrom.mockReturnValue(mockSelectExpenditure(fakeExpenditure));
+      const res = await handler(idEvent('GET', '5'));
+
+      expect(res.headers?.['Content-Type']).toBe('application/json');
+      expect(res.headers?.['Access-Control-Allow-Origin']).toBe('*');
+      expect(res.headers?.['Access-Control-Allow-Methods']).toContain('GET');
+    });
+  });
+});
+
+
+describe('DELETE /expenditures/{id} unit tests', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuthenticateRequest.mockResolvedValue(adminAuthContext);
+  });
+
+  describe('Validation', () => {
+    test('400: non-numeric id', async () => {
+      const res = await handler(idEvent('DELETE', 'abc'));
+      expect(res.statusCode).toBe(400);
+    });
+
+    test('400: negative id', async () => {
+      const res = await handler(idEvent('DELETE', '-1'));
+      expect(res.statusCode).toBe(400);
+    });
+  });
+
+  describe('Authentication', () => {
+    test('401: unauthenticated request is rejected', async () => {
+      mockAuthenticateRequest.mockResolvedValue({ isAuthenticated: false });
+      const res = await handler(idEvent('DELETE', '5'));
+      expect(res.statusCode).toBe(401);
+    });
+  });
+
+  describe('Not found', () => {
+    test('404: expenditure does not exist (checked before authorization)', async () => {
+      mockDb.selectFrom.mockReturnValue(mockSelectExpenditure(null));
+      const res = await handler(idEvent('DELETE', '999'));
+
+      expect(res.statusCode).toBe(404);
+      expect(JSON.parse(res.body).message).toBe('Expenditure not found');
+      // deleteFrom should never be reached if the expenditure lookup fails
+      expect(mockDb.deleteFrom).not.toHaveBeenCalled();
+    });
+
+    test('404: row already gone by the time delete executes (race condition)', async () => {
+      mockDb.selectFrom.mockReturnValueOnce(mockSelectExpenditure(fakeExpenditure));
+      mockDb.deleteFrom.mockReturnValue(mockDelete(0n));
+
+      const res = await handler(idEvent('DELETE', '5'));
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  describe('Authorization', () => {
+    test('403: non-admin with no membership on the project', async () => {
+      mockAuthenticateRequest.mockResolvedValue(staffAuthContext);
+      mockDb.selectFrom
+        .mockReturnValueOnce(mockSelectExpenditure(fakeExpenditure)) // expenditure lookup
+        .mockReturnValueOnce(mockMembership(null)); // no membership row
+
+      const res = await handler(idEvent('DELETE', '5'));
+      expect(res.statusCode).toBe(403);
+      expect(JSON.parse(res.body).message).toBe('Unable to delete this expenditure');
+      expect(mockDb.deleteFrom).not.toHaveBeenCalled();
+    });
+
+    test('403: user with Staff role on the project is rejected', async () => {
+      mockAuthenticateRequest.mockResolvedValue(staffAuthContext);
+      mockDb.selectFrom
+        .mockReturnValueOnce(mockSelectExpenditure(fakeExpenditure))
+        .mockReturnValueOnce(mockMembership({ role: 'Staff' }));
+
+      const res = await handler(idEvent('DELETE', '5'));
+      expect(res.statusCode).toBe(403);
+    });
+
+    test('membership check is scoped to the expenditure\'s own project_id, not the path id', async () => {
+      mockAuthenticateRequest.mockResolvedValue(piAuthContext);
+      const membershipWhereProjectSpy = jest.fn().mockReturnValue({
+        where: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            executeTakeFirst: jest.fn().mockReturnValue({ role: 'PI' }),
+          }),
+        }),
+      });
+
+      mockDb.selectFrom
+        .mockReturnValueOnce(mockSelectExpenditure(fakeExpenditure)) // project_id: 1
+        .mockReturnValueOnce({ where: membershipWhereProjectSpy });
+      mockDb.deleteFrom.mockReturnValue(mockDelete(1n));
+
+      await handler(idEvent('DELETE', '5'));
+      expect(membershipWhereProjectSpy).toHaveBeenCalledWith('project_id', '=', fakeExpenditure.project_id);
+    });
+  });
+
+  describe('Success cases', () => {
+    test('200: admin can delete without a membership lookup', async () => {
+      mockDb.selectFrom.mockReturnValueOnce(mockSelectExpenditure(fakeExpenditure));
+      mockDb.deleteFrom.mockReturnValue(mockDelete(1n));
+
+      const res = await handler(idEvent('DELETE', '5'));
+
+      expect(res.statusCode).toBe(200);
+      const json = JSON.parse(res.body);
+      expect(json.ok).toBe(true);
+      expect(json.route).toBe('DELETE /expenditures/{id}');
+      expect(json.pathParams).toEqual({ id: '5' });
+    });
+
+    test('200: PI on the expenditure\'s project can delete', async () => {
+      mockAuthenticateRequest.mockResolvedValue(piAuthContext);
+      mockDb.selectFrom
+        .mockReturnValueOnce(mockSelectExpenditure(fakeExpenditure))
+        .mockReturnValueOnce(mockMembership({ role: 'PI' }));
+      mockDb.deleteFrom.mockReturnValue(mockDelete(1n));
+
+      const res = await handler(idEvent('DELETE', '5'));
+      expect(res.statusCode).toBe(200);
+    });
+
+    test('200: Accountant on the expenditure\'s project can delete', async () => {
+      const accountantAuthContext = {
+        isAuthenticated: true as const,
+        user: { cognitoSub: 'acct-sub', userId: 4, email: 'acct@example.com', isAdmin: false },
+      };
+      mockAuthenticateRequest.mockResolvedValue(accountantAuthContext);
+      mockDb.selectFrom
+        .mockReturnValueOnce(mockSelectExpenditure(fakeExpenditure))
+        .mockReturnValueOnce(mockMembership({ role: 'Accountant' }));
+      mockDb.deleteFrom.mockReturnValue(mockDelete(1n));
+
+      const res = await handler(idEvent('DELETE', '5'));
+      expect(res.statusCode).toBe(200);
     });
   });
 });

--- a/apps/backend/lambdas/expenditures/test/expenditures.unit.test.ts
+++ b/apps/backend/lambdas/expenditures/test/expenditures.unit.test.ts
@@ -699,6 +699,29 @@ describe('GET /expenditures/{id} unit tests', () => {
     });
   });
 
+  describe('Authorization', () => {
+    test('403: non-admin with no project membership cannot read', async () => {
+      mockAuthenticateRequest.mockResolvedValue(staffAuthContext);
+      mockDb.selectFrom
+        .mockReturnValueOnce(mockSelectExpenditure(fakeExpenditure)) // expenditure lookup
+        .mockReturnValueOnce(mockMembership(null)); // no membership row
+
+      const res = await handler(idEvent('GET', '5'));
+      expect(res.statusCode).toBe(403);
+      expect(JSON.parse(res.body).message).toBe('Unable to view this expenditure');
+    });
+
+    test('200: non-admin with membership on the project can read', async () => {
+      mockAuthenticateRequest.mockResolvedValue(staffAuthContext);
+      mockDb.selectFrom
+        .mockReturnValueOnce(mockSelectExpenditure(fakeExpenditure)) // expenditure lookup
+        .mockReturnValueOnce(mockMembership({ role: 'Staff' })); // has a role on the project
+
+      const res = await handler(idEvent('GET', '5'));
+      expect(res.statusCode).toBe(200);
+    });
+  });
+
   describe('Success cases', () => {
     test('200: admin can read any expenditure', async () => {
       mockDb.selectFrom.mockReturnValue(mockSelectExpenditure(fakeExpenditure));
@@ -711,14 +734,6 @@ describe('GET /expenditures/{id} unit tests', () => {
       expect(json.body.expenditureId).toBe(5);
       expect(json.body.projectId).toBe(1);
       expect(json.body.amount).toBe('1200');
-    });
-
-    test('200: authenticated non-admin with no project membership can still read (read is not project-scoped)', async () => {
-      mockAuthenticateRequest.mockResolvedValue(staffAuthContext);
-      mockDb.selectFrom.mockReturnValue(mockSelectExpenditure(fakeExpenditure));
-
-      const res = await handler(idEvent('GET', '5'));
-      expect(res.statusCode).toBe(200);
     });
 
     test('response has correct HTTP headers', async () => {


### PR DESCRIPTION
### ℹ️ Issue

Closes #247 

### 📝 Description

Added the GET /expenditures/{id} and DELETE /expenditures/{id} endpoints to the expenditures lambda.

Briefly list the changes made to the code:
1. Wrote the logic for the 2 new endpoints; for the DELETE endpoint, I used the same authorization checks that the POST endpoint used
2. Wrote e2e & unit tests for these
3. Checked on Swagger UI to ensure endpoints worked

### ✔️ Verification

Ran tests via jest and tested through Swagger UI
<img width="1010" height="371" alt="Screenshot 2026-07-12 003141" src="https://github.com/user-attachments/assets/66ffa042-3c3b-4c7a-bedc-b3fa18a3ed98" />

GET:
<img width="986" height="689" alt="Screenshot 2026-07-12 003505" src="https://github.com/user-attachments/assets/d7c43b98-aadc-4972-9d31-e95806aa3257" />
<img width="1228" height="692" alt="Screenshot 2026-07-12 004911" src="https://github.com/user-attachments/assets/6b1198ff-8573-4c92-babc-4ae13641537e" />
<img width="1235" height="692" alt="Screenshot 2026-07-12 004923" src="https://github.com/user-attachments/assets/c2a35c99-1e74-42b8-ac02-ed2fe4495cdb" />
<img width="925" height="691" alt="Screenshot 2026-07-12 004945" src="https://github.com/user-attachments/assets/45885079-be14-4749-bd58-b1ba74639b76" />

DELETE:
<img width="926" height="680" alt="Screenshot 2026-07-12 004958" src="https://github.com/user-attachments/assets/0f38cc0f-66be-49f6-93b5-ffdfbacb1a95" />
<img width="932" height="691" alt="Screenshot 2026-07-12 005031" src="https://github.com/user-attachments/assets/8bafb5d2-df01-48be-aec1-23eb36193682" />


### 🏕️ (Optional) Future Work / Notes

Did you notice anything ugly during the course of this ticket? Any bugs, design challenges, or unexpected behavior? Write it down so we can clean it up in a future ticket!
