### PR TITLE
feat(ci): add no-review label to opt PRs out of the review bot

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -25,11 +25,21 @@ State lives on the **`bot-state`** branch (provisioned by `infrastructure/github
 
 | Workflow | Trigger | Does |
 |----------|---------|------|
-| `pr-reviewer-assign.yml` | PR opened/ready/reopened (not draft) | Round-robin pick reviewer(s) skipping author (+ always-reviewer), request review, post Slack message, persist cursor + per-PR file. Idempotent. |
+| `pr-reviewer-assign.yml` | PR opened/ready/reopened/unlabeled (not draft, not `no-review`) | Round-robin pick reviewer(s) skipping author (+ always-reviewer), request review, post Slack message, persist cursor + per-PR file. Idempotent. |
 | `pr-review-status.yml` | review submitted (approved/changes_requested) | Recompute per-reviewer status, update Slack message + thread reply, DM author when all done, mark `reviewed`. |
 | `pr-reviewer-remind.yml` | cron `0 */6 * * *`, or manual | For open PRs with pending reviewers and 36h+ since last reminder → Slack reminder; GC terminal PR files after 7 days. |
 | `pr-closed.yml` | PR closed | Strikethrough Slack header, mark file `merged`/`closed`. |
+| `pr-no-review-label.yml` | `no-review` label added | Remove the bot's review requests, delete the Slack message + thread replies, delete the per-PR file. |
 | `merge-queue-dequeued.yml` | PR `dequeued` | DM author the dequeue reason. |
+
+### The `no-review` opt-out label
+
+Adding **`no-review`** to a PR takes it out of the bot completely: no reviewer
+assignment, no Slack post, no reminders. It works before *and* after assignment —
+if the bot already ran, `pr-no-review-label.yml` unwinds it. Removing the label
+re-runs assignment (via the `unlabeled` trigger on `pr-reviewer-assign.yml`).
+The label is created in the GitHub UI, not Terraform. Note this only silences the
+bot — `main` branch protection still requires 2 approvals.
 
 ## Editing notes
 

--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -11,6 +11,9 @@ permissions:
 jobs:
   update-status:
     runs-on: ubuntu-latest
+    # PRs labelled `no-review` are untracked by pr-no-review-label.yml, so
+    # there is no Slack message or state file left to update.
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-review') }}
     steps:
       - name: Checkout bot-state branch
         uses: actions/checkout@v4

--- a/.github/workflows/pr-no-review-label.yml
+++ b/.github/workflows/pr-no-review-label.yml
@@ -1,0 +1,172 @@
+name: PR No-Review Opt-Out
+
+# Adding the `no-review` label opts a PR out of the review bot entirely.
+# pr-reviewer-assign.yml already refuses to assign a labelled PR, but the label
+# can also land *after* the bot assigned reviewers and posted to Slack. This
+# workflow undoes that: it drops the review requests, removes the Slack
+# message (and any thread replies), and deletes the per-PR state file so the
+# reminder cron and the status/closed workflows stop seeing the PR.
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  untrack:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.label.name == 'no-review' }}
+    steps:
+      - name: Checkout bot-state branch
+        uses: actions/checkout@v4
+        with:
+          ref: bot-state
+          path: bot-state
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Untrack PR and clean up Slack
+        uses: actions/github-script@v7
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const BOT_STATE_DIR = 'bot-state';
+            const configPath = path.join(BOT_STATE_DIR, 'config.json');
+            const prsDir = path.join(BOT_STATE_DIR, 'prs');
+
+            const prNumber = context.payload.pull_request.number;
+            const prFileKey = `${context.repo.owner}_${context.repo.repo}_${prNumber}`;
+            const prFilePath = path.join(prsDir, `${prFileKey}.json`);
+
+            if (!fs.existsSync(prFilePath)) {
+              console.log(`No per-PR file for #${prNumber}. Nothing to untrack.`);
+              return;
+            }
+            if (!fs.existsSync(configPath)) {
+              console.log('config.json not found. Skipping Slack cleanup.');
+              return;
+            }
+
+            const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+            const prData = JSON.parse(fs.readFileSync(prFilePath, 'utf8'));
+
+            // ── Slack helper ─────────────────────────────────────────
+            // Read methods (conversations.replies) need GET with query-string
+            // params; write methods (chat.delete) use POST JSON.
+            const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+
+            async function slackApi(method, params, verb = 'POST') {
+              for (let attempt = 0; attempt < 4; attempt++) {
+                try {
+                  let url = `https://slack.com/api/${method}`;
+                  const opts = {
+                    method: verb,
+                    headers: { Authorization: `Bearer ${process.env.SLACK_BOT_TOKEN}` },
+                  };
+                  if (verb === 'GET') {
+                    url += '?' + new URLSearchParams(params).toString();
+                  } else {
+                    opts.headers['Content-Type'] = 'application/json; charset=utf-8';
+                    opts.body = JSON.stringify(params);
+                  }
+                  const resp = await fetch(url, opts);
+                  if (resp.status === 429) {
+                    const wait = (parseInt(resp.headers.get('retry-after') || '1', 10) || 1) * 1000;
+                    await sleep(wait);
+                    continue;
+                  }
+                  const data = await resp.json();
+                  if (!data.ok && data.error === 'ratelimited') { await sleep(1000); continue; }
+                  if (!data.ok) console.log(`Slack ${method} error: ${data.error}`);
+                  return data;
+                } catch (err) {
+                  console.log(`Slack ${method} failed: ${err.message}`);
+                  return { ok: false };
+                }
+              }
+              return { ok: false, error: 'rate_limit_retries_exhausted' };
+            }
+
+            // ── Drop the bot's review requests ───────────────────────
+            const reviewers = [prData.main_reviewer, prData.second_reviewer].filter(Boolean);
+            if (reviewers.length > 0) {
+              try {
+                await github.rest.pulls.removeRequestedReviewers({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: prNumber,
+                  reviewers,
+                });
+                console.log(`Removed review requests: ${reviewers.join(', ')}`);
+              } catch (err) {
+                console.log(`Warning: could not remove reviewers: ${err.message}`);
+              }
+            }
+
+            // ── Delete the Slack message and its thread replies ──────
+            if (prData.slack_thread_ts) {
+              const channel = config.slack_channel_id;
+              const parentTs = prData.slack_thread_ts;
+              const tsList = [];
+
+              let cursor;
+              do {
+                const replies = await slackApi('conversations.replies', {
+                  channel, ts: parentTs, limit: 200, ...(cursor ? { cursor } : {}),
+                }, 'GET');
+                if (!replies.ok) {
+                  console.log(`Could not list thread replies: ${replies.error}`);
+                  break;
+                }
+                for (const r of replies.messages || []) {
+                  if (r.ts !== parentTs) tsList.push(r.ts);
+                }
+                cursor = replies.response_metadata && replies.response_metadata.next_cursor;
+              } while (cursor);
+
+              // Replies first so the parent is never left with orphans.
+              tsList.push(parentTs);
+              for (const ts of tsList) {
+                const res = await slackApi('chat.delete', { channel, ts });
+                if (!res.ok) console.log(`Could not delete message ${ts}: ${res.error}`);
+                // chat.delete is Tier 3 (~50/min); ~1.2s keeps us under it.
+                await sleep(1200);
+              }
+              console.log(`Deleted ${tsList.length} Slack message(s) for PR #${prNumber}`);
+            }
+
+            // ── Drop the per-PR state file ───────────────────────────
+            fs.unlinkSync(prFilePath);
+            console.log(`Untracked PR #${prNumber} (no-review label)`);
+
+      - name: Commit and push bot-state
+        working-directory: bot-state
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+
+          git commit -m "bot: untrack PR #${{ github.event.pull_request.number }} (no-review label)"
+
+          for attempt in 1 2 3; do
+            if git pull --rebase origin bot-state && git push origin bot-state; then
+              echo "Push succeeded (attempt $attempt)"
+              exit 0
+            fi
+            echo "Push attempt $attempt failed, retrying in 2s…"
+            sleep 2
+          done
+
+          echo "::error::Failed to push bot-state after 3 attempts"
+          exit 1

--- a/.github/workflows/pr-review-status.yml
+++ b/.github/workflows/pr-review-status.yml
@@ -11,10 +11,12 @@ permissions:
 jobs:
   update-status:
     runs-on: ubuntu-latest
-    # Only act on real reviews, not PENDING (draft reviews)
+    # Only act on real reviews, not PENDING (draft reviews), and never on a
+    # PR that opted out with `no-review`.
     if: >-
-      github.event.review.state == 'approved' ||
-      github.event.review.state == 'changes_requested'
+      (github.event.review.state == 'approved' ||
+       github.event.review.state == 'changes_requested') &&
+      !contains(github.event.pull_request.labels.*.name, 'no-review')
     steps:
       - name: Checkout bot-state branch
         uses: actions/checkout@v4

--- a/.github/workflows/pr-reviewer-assign.yml
+++ b/.github/workflows/pr-reviewer-assign.yml
@@ -2,7 +2,9 @@ name: PR Reviewer Assignment
 
 on:
   pull_request:
-    types: [opened, ready_for_review, reopened]
+    # `unlabeled` is here so that removing `no-review` assigns a reviewer after
+    # the fact; the job `if` below narrows it to that one label.
+    types: [opened, ready_for_review, reopened, unlabeled]
 
 permissions:
   contents: write
@@ -11,7 +13,13 @@ permissions:
 jobs:
   assign-reviewer:
     runs-on: ubuntu-latest
-    if: ${{ !github.event.pull_request.draft }}
+    # Skip drafts and any PR carrying the `no-review` opt-out label. On an
+    # `unlabeled` event the payload already reflects the post-removal label
+    # set, so a `no-review` removal passes the `contains` check.
+    if: >-
+      ${{ !github.event.pull_request.draft
+          && !contains(github.event.pull_request.labels.*.name, 'no-review')
+          && (github.event.action != 'unlabeled' || github.event.label.name == 'no-review') }}
     steps:
       - name: Checkout bot-state branch
         uses: actions/checkout@v4

--- a/.github/workflows/pr-reviewer-remind.yml
+++ b/.github/workflows/pr-reviewer-remind.yml
@@ -118,6 +118,15 @@ jobs:
                 continue;
               }
 
+              // ── Respect the `no-review` opt-out label ──────────────
+              // pr-no-review-label.yml normally deletes the per-PR file when
+              // the label goes on, but this cron is the backstop for a PR that
+              // was labelled while that workflow was failing or disabled.
+              if ((ghPr.labels || []).some(l => l.name === 'no-review')) {
+                console.log(`PR #${prData.pr_number} is labelled no-review. Skipping reminder.`);
+                continue;
+              }
+
               // ── Check if reviewers have submitted reviews ──────────
               let reviews = [];
               try {


### PR DESCRIPTION
## What

Adding the **`no-review`** label to a PR now takes it out of the review bot entirely — no round-robin reviewer assignment, no Slack post, no reminders.

## Why

There was no way to tell the bot to skip a PR. Trivial changes, docs tweaks, and revert PRs all burned a reviewer slot and posted to `#proj-branch-*`.

## How

The label works **before and after** the bot has already run.

| File | Change |
|------|--------|
| `pr-reviewer-assign.yml` | Job `if` skips PRs carrying `no-review`. Added an `unlabeled` trigger (narrowed to that one label) so removing the label assigns a reviewer after the fact. |
| `pr-no-review-label.yml` **(new)** | On `no-review` being added: remove the bot's review requests, delete the Slack message + thread replies, delete the per-PR state file, commit `bot-state`. |
| `pr-reviewer-remind.yml` | Skips any PR whose live GitHub labels include `no-review` — backstop for a PR labelled while the untrack workflow was failing. |
| `pr-review-status.yml`, `pr-closed.yml` | Job-level `if` guard. Mostly belt-and-braces: once untracked there is no state file left for them to act on. |
| `.github/AGENTS.md` | Documented the label and the new workflow. |

Deleting the per-PR state file is what makes this stick — every downstream workflow keys off `prs/{owner}_{repo}_{prNumber}.json` and no-ops when it is missing.

## Notes

- **The `no-review` label must be created in the GitHub UI** — it is not declared in Terraform (neither is the existing `test-environment` label, so this matches convention). The workflows are inert until it exists.
- This only silences the bot. `main` branch protection still requires 2 approvals, so a `no-review` PR cannot be merged unreviewed.
- `chat.delete` on thread replies reuses the GET-vs-POST Slack helper pattern already proven in `slack-purge-bot-messages.yml`.

## Testing

Static only — these paths need real `pull_request` events and `SLACK_BOT_TOKEN` to exercise:
- All five workflow YAMLs parse (`yaml.safe_load`).
- The embedded `github-script` JS passes `node --check`.

Worth a live smoke test after merge: open a throwaway PR, confirm assignment + Slack post, add `no-review`, confirm the reviewers drop and the Slack message disappears, then remove the label and confirm reassignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)