### PR TITLE
fix(infra): make prod RDS reachable from the lambdas

### DIFF
--- a/apps/backend/lambdas/auth/db.ts
+++ b/apps/backend/lambdas/auth/db.ts
@@ -11,7 +11,15 @@ const db = new Kysely<DB>({
       user: process.env.DB_USER ?? 'branch_dev',
       password: process.env.DB_PASSWORD ?? 'password',
       database: process.env.DB_NAME ?? 'branch_db',
-      ssl: false, 
+
+      // rds.force_ssl = 1 on default.postgres17 rejects unencrypted connections,
+      // so ssl: false never worked against prod. Local postgres has no TLS.
+      // TODO: pin the RDS CA bundle instead of skipping verification.
+      ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
+
+      // Without this a blackholed SYN hangs until the 30s lambda timeout instead
+      // of erroring, which is how the unreachable-database bug presented.
+      connectionTimeoutMillis: 5000,
     }),
   }),
 })

--- a/apps/backend/lambdas/donors/db.ts
+++ b/apps/backend/lambdas/donors/db.ts
@@ -11,7 +11,15 @@ const db = new Kysely<DB>({
       user: process.env.DB_USER ?? 'branch_dev',
       password: process.env.DB_PASSWORD ?? 'password',
       database: process.env.DB_NAME ?? 'branch_db',
-      ssl: false, 
+
+      // rds.force_ssl = 1 on default.postgres17 rejects unencrypted connections,
+      // so ssl: false never worked against prod. Local postgres has no TLS.
+      // TODO: pin the RDS CA bundle instead of skipping verification.
+      ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
+
+      // Without this a blackholed SYN hangs until the 30s lambda timeout instead
+      // of erroring, which is how the unreachable-database bug presented.
+      connectionTimeoutMillis: 5000,
     }),
   }),
 })

--- a/apps/backend/lambdas/expenditures/db.ts
+++ b/apps/backend/lambdas/expenditures/db.ts
@@ -11,7 +11,15 @@ const db = new Kysely<DB>({
       user: process.env.DB_USER ?? 'branch_dev',
       password: process.env.DB_PASSWORD ?? 'password',
       database: process.env.DB_NAME ?? 'branch_db',
-      ssl: false, 
+
+      // rds.force_ssl = 1 on default.postgres17 rejects unencrypted connections,
+      // so ssl: false never worked against prod. Local postgres has no TLS.
+      // TODO: pin the RDS CA bundle instead of skipping verification.
+      ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
+
+      // Without this a blackholed SYN hangs until the 30s lambda timeout instead
+      // of erroring, which is how the unreachable-database bug presented.
+      connectionTimeoutMillis: 5000,
     }),
   }),
 })

--- a/apps/backend/lambdas/projects/db.ts
+++ b/apps/backend/lambdas/projects/db.ts
@@ -10,7 +10,15 @@ const db = new Kysely<DB>({
       user: process.env.DB_USER ?? 'branch_dev',
       password: process.env.DB_PASSWORD ?? 'password',
       database: process.env.DB_NAME ?? 'branch_db',
-      ssl: false, 
+
+      // rds.force_ssl = 1 on default.postgres17 rejects unencrypted connections,
+      // so ssl: false never worked against prod. Local postgres has no TLS.
+      // TODO: pin the RDS CA bundle instead of skipping verification.
+      ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
+
+      // Without this a blackholed SYN hangs until the 30s lambda timeout instead
+      // of erroring, which is how the unreachable-database bug presented.
+      connectionTimeoutMillis: 5000,
     }),
   }),
 })

--- a/apps/backend/lambdas/reports/db.ts
+++ b/apps/backend/lambdas/reports/db.ts
@@ -10,7 +10,15 @@ const db = new Kysely<DB>({
       user: process.env.DB_USER ?? 'branch_dev',
       password: process.env.DB_PASSWORD ?? 'password',
       database: process.env.DB_NAME ?? 'branch_db',
-      ssl: false,
+
+      // rds.force_ssl = 1 on default.postgres17 rejects unencrypted connections,
+      // so ssl: false never worked against prod. Local postgres has no TLS.
+      // TODO: pin the RDS CA bundle instead of skipping verification.
+      ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
+
+      // Without this a blackholed SYN hangs until the 30s lambda timeout instead
+      // of erroring, which is how the unreachable-database bug presented.
+      connectionTimeoutMillis: 5000,
     }),
   }),
 })

--- a/apps/backend/lambdas/users/db.ts
+++ b/apps/backend/lambdas/users/db.ts
@@ -11,7 +11,15 @@ const db = new Kysely<DB>({
       user: process.env.DB_USER ?? 'branch_dev',
       password: process.env.DB_PASSWORD ?? 'password',
       database: process.env.DB_NAME ?? 'branch_db',
-      ssl: false, 
+
+      // rds.force_ssl = 1 on default.postgres17 rejects unencrypted connections,
+      // so ssl: false never worked against prod. Local postgres has no TLS.
+      // TODO: pin the RDS CA bundle instead of skipping verification.
+      ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
+
+      // Without this a blackholed SYN hangs until the 30s lambda timeout instead
+      // of erroring, which is how the unreachable-database bug presented.
+      connectionTimeoutMillis: 5000,
     }),
   }),
 })

--- a/infrastructure/aws/README.md
+++ b/infrastructure/aws/README.md
@@ -62,12 +62,16 @@ No modules.
 | [aws_s3_bucket_server_side_encryption_configuration.lambda_deployments](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_versioning.lambda_deployments](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/s3_bucket_versioning) | resource |
 | [aws_s3_object.lambda_placeholder](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/s3_object) | resource |
+| [aws_security_group.rds](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/security_group) | resource |
+| [aws_vpc_security_group_egress_rule.rds_all](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/vpc_security_group_egress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.rds_postgres](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [archive_file.lambda_placeholder](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.ci_apply_assume](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ci_plan_assume](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ci_preview_assume](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.frontend_bucket](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/data-sources/iam_policy_document) | data source |
+| [aws_vpc.default](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/data-sources/vpc) | data source |
 | [infisical_secrets.github_folder](https://registry.terraform.io/providers/infisical/infisical/latest/docs/data-sources/secrets) | data source |
 | [infisical_secrets.rds_folder](https://registry.terraform.io/providers/infisical/infisical/latest/docs/data-sources/secrets) | data source |
 

--- a/infrastructure/aws/main.tf
+++ b/infrastructure/aws/main.tf
@@ -12,4 +12,57 @@ resource "aws_db_instance" "branch_rds" {
   username                   = data.infisical_secrets.rds_folder.secrets["username"].value
   password                   = data.infisical_secrets.rds_folder.secrets["password"].value
   skip_final_snapshot        = true
+
+  # The lambdas in lambda.tf have no vpc_config, so they run outside any VPC and
+  # had no route to this instance while it was private -- every DB-backed request
+  # hung until the 30s lambda timeout. Putting them in the VPC instead is the
+  # stronger fix but costs a NAT gateway (~$33/mo) or a cognito-idp interface
+  # endpoint (~$7/mo), since a VPC lambda with no internet route cannot reach
+  # Cognito. Traded away for $0.
+  publicly_accessible = true
+
+  # Replaces the VPC default SG, which allowed all protocols from 0.0.0.0/0.
+  vpc_security_group_ids = [aws_security_group.rds.id]
+
+  # skip_final_snapshot = true means any replacement destroys the database with
+  # no backup, and edits like db_subnet_group_name force replacement.
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# Open to the internet on 5432, because non-VPC lambda egress IPs are not
+# enumerable: there is no LAMBDA tag in ip-ranges.json, and those lambdas egress
+# from the region's EC2 pool (~4.4M addresses in us-east-2). No narrower CIDR
+# would still admit them, so the master password is the real control -- rotate it,
+# and prefer moving the lambdas into the VPC over keeping this.
+resource "aws_security_group" "rds" {
+  name        = "branch-rds-sg"
+  description = "branch_rds: postgres from anywhere (lambdas run outside the VPC)"
+  vpc_id      = data.aws_vpc.default.id
+
+  tags = {
+    Name      = "branch-rds-sg"
+    ManagedBy = "terraform"
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "rds_postgres" {
+  security_group_id = aws_security_group.rds.id
+  description       = "Postgres from anywhere; lambda egress IPs are not enumerable"
+  ip_protocol       = "tcp"
+  from_port         = 5432
+  to_port           = 5432
+  cidr_ipv4         = "0.0.0.0/0"
+}
+
+# The provider deletes AWS's implicit allow-all egress rule unless it is declared.
+resource "aws_vpc_security_group_egress_rule" "rds_all" {
+  security_group_id = aws_security_group.rds.id
+  ip_protocol       = "-1"
+  cidr_ipv4         = "0.0.0.0/0"
+}
+
+data "aws_vpc" "default" {
+  default = true
 }


### PR DESCRIPTION
## Problem

`GET /auth/me` from the frontend hung for ~30s and returned nothing. Root cause was not application logic — **nothing in the deployed stack has ever been able to reach the production database.** That is also why prod had no schema until it was applied by hand.

## Three defects, all required for one request to work

**1. The lambdas had no route to the database.** `aws_db_instance.branch_rds` never set `publicly_accessible`, so it defaulted to `false` and its endpoint only resolved to a private address inside the default VPC. The six lambdas have no `vpc_config` and run outside any VPC. Fixed with `publicly_accessible = true`.

The stronger fix is putting the lambdas *in* the VPC. Rejected on cost: a VPC lambda with no internet route can't reach Cognito, which all six do on cold start (`aws-jwt-verify` JWKS fetch), so it needs a NAT gateway (~\$33/mo) or a `cognito-idp` interface endpoint (~\$7/mo). Consciously traded away for \$0.

**2. TLS was disabled but mandatory.** `rds.force_ssl = 1` on `default.postgres17`, while all six `db.ts` hardcoded `ssl: false` — Postgres would have rejected these connections even once routable, with `no pg_hba.conf entry for host ..., no encryption`. Enabled in production only; local docker-compose Postgres has no TLS.

Worth noting this was masked: manual `psql` worked because psql defaults to `sslmode=prefer` and silently negotiated TLS.

**3. Failures hung instead of erroring.** `pg` had no `connectionTimeoutMillis`. A blackholed SYN never gets an RST, so the pool waited forever, turning a network fault into a 30s function timeout with nothing logged. Set to 5s, well inside API Gateway's 29s integration ceiling.

## Security change

Replaces the VPC **default** security group on the instance — which allowed **all protocols from `0.0.0.0/0`** — with `branch-rds-sg` scoped to 5432. This was survivable while the instance was unreachable; it would not be now that the endpoint is public.

The rule is still `0.0.0.0/0` on 5432, and that is deliberate rather than lazy: AWS publishes no Lambda egress ranges (there is no `LAMBDA` tag in `ip-ranges.json`), and non-VPC lambdas egress from the region's EC2 pool — 83 CIDR blocks, ~4.4M addresses in us-east-2, i.e. every EC2 instance of every AWS customer in Ohio. No narrower CIDR would still admit our own lambdas. **The master password is therefore the real control.**

Also adds `prevent_destroy`: `skip_final_snapshot = true` means any replacement (e.g. an innocuous-looking `db_subnet_group_name` edit) would silently destroy the database with no backup.

## Verification

- `terraform validate` passes; `terraform fmt -check` clean.
- All six lambdas typecheck clean (`tsc --noEmit`) after installing workspace deps and building `shared/lambda-auth`.
- **Not yet verified end-to-end against deployed infra** — needs `terraform apply` and a lambda deploy, then `GET /auth/me` should return the admin user with `isAdmin: true`.

## Follow-ups (not in this PR)

- **Rotate the master password.** It is weak and was readable from plaintext lambda env vars.
- Pin the RDS CA bundle so TLS is authenticated, not just encrypted (currently `rejectUnauthorized: false`). Needs a shared package so the PEM isn't copied six times.
- Add a mechanism that applies `db_setup.sql` to prod — nothing in CI ever has (`lambda-tests.yml` and `regenerate-db-types.yaml` both target localhost).
- Consider collapsing the six identical `db.ts` files into a `shared/lambda-db` package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)