### PR TITLE
fix(infra): drop backup_window so the RDS change can apply

### DIFF
--- a/infrastructure/aws/main.tf
+++ b/infrastructure/aws/main.tf
@@ -13,14 +13,11 @@ resource "aws_db_instance" "branch_rds" {
   password                   = data.infisical_secrets.rds_folder.secrets["password"].value
   skip_final_snapshot        = true
 
-  # Set explicitly because CI now applies schema migrations to this instance
-  # automatically (the `migrate` job in .github/workflows/lambda-deploy.yml). That
-  # job takes a named pre-migration snapshot, but point-in-time recovery is the
-  # backstop for everything else, and this was previously left to whatever the API
-  # defaulted to. Backup storage up to allocated_storage (10 GB) is free, so 7
-  # days of PITR costs nothing.
+  # Was 0 -- no point-in-time recovery at all. Free at this size, and the backstop
+  # for CI-applied migrations. backup_window is deliberately unset: AWS rejects a
+  # backup window that overlaps the maintenance window, and neither is managed here,
+  # so pinning one guesses against the other. Pin both or neither.
   backup_retention_period = 7
-  backup_window           = "07:00-08:00" # UTC — off-hours for a US-based club
 
   # The lambdas in lambda.tf have no vpc_config, so they run outside any VPC and
   # had no route to this instance while it was private -- every DB-backed request


### PR DESCRIPTION
`terraform-apply` failed on main after #293 merged:

```
Error: updating RDS DB Instance: ModifyDBInstance
InvalidParameterValue: The backup window and maintenance window must not overlap.
```

## Cause

My fault in #293. `backup_retention_period = 0 -> 7` was the change that mattered — production had **no point-in-time recovery at all**. I bundled `backup_window = "07:00-08:00"` next to it as a timing tweak nobody asked for.

Terraform manages neither `backup_window` nor `maintenance_window` on `branch_rds` — AWS assigned both. Pinning one guesses against the other, and AWS cross-validates them.

## Fix

Drop `backup_window`. Keep `backup_retention_period = 7`.

The windows AWS assigned already don't overlap, and a backup of a few MB on a `db.t3.micro` is seconds of I/O, so there was nothing to gain. If specific times are ever wanted, pin `backup_window` **and** `maintenance_window` together.

## State

The failed apply was partial — it created `aws_iam_role.ci_migrate` before erroring on the RDS modify. Re-applying reconciles the remainder; nothing needs manual cleanup. Expect the plan here to show the RDS in-place update plus whatever `ci_migrate` resources didn't land.

Note PITR is **still off in production** until this applies, so the pre-migration snapshot in the `migrate` job is currently the only rollback lever.

`terraform validate` and `fmt` pass locally; I can't run a real plan (no credentials for account 489881683177), so the plan comment on this PR is the check that matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)