### PR TITLE
feat(roles): project roles are Admin, Director, Student

### DIFF
--- a/apps/backend/db/migrations/20260812011405_rename_project_roles.sql
+++ b/apps/backend/db/migrations/20260812011405_rename_project_roles.sql
@@ -1,0 +1,13 @@
+-- PI + Accountant -> Director, Staff -> Student, Admin unchanged.
+-- Expand phase: the CHECK still accepts the old names so the deployed code can
+-- keep writing them until it is replaced. A later migration drops them.
+
+ALTER TABLE project_memberships
+    DROP CONSTRAINT IF EXISTS project_memberships_role_check;
+
+ALTER TABLE project_memberships
+    ADD CONSTRAINT project_memberships_role_check
+    CHECK (role IN ('Admin', 'Director', 'Student', 'PI', 'Accountant', 'Staff'));
+
+UPDATE project_memberships SET role = 'Director' WHERE role IN ('PI', 'Accountant');
+UPDATE project_memberships SET role = 'Student' WHERE role = 'Staff';

--- a/apps/backend/db/seed.sql
+++ b/apps/backend/db/seed.sql
@@ -38,9 +38,9 @@ INSERT INTO branch.project_donations (donor_id, project_id, amount, donated_at) 
 (3, 3, 90000, '2025-06-20');
 
 INSERT INTO branch.project_memberships (project_id, user_id, role, start_date, hours) VALUES
-(1, 1, 'PI', '2025-01-01', 100.00),
-(1, 2, 'Accountant', '2025-02-01', 80.00),
-(2, 3, 'Staff', '2025-03-15', 60.00);
+(1, 1, 'Director', '2025-01-01', 100.00),
+(1, 2, 'Director', '2025-02-01', 80.00),
+(2, 3, 'Student', '2025-03-15', 60.00);
 
 INSERT INTO branch.expenditures (project_id, entered_by, amount, category, description, spent_on) VALUES
 (1, 1, 5000, 'Travel', 'Domestic conference attendance', '2025-02-10'),

--- a/apps/backend/lambdas/donors/test/donors.test.ts
+++ b/apps/backend/lambdas/donors/test/donors.test.ts
@@ -431,8 +431,8 @@ describe("Donor API with data", () => {
       }
     });
 
-    test("DELETE /donations/{id} returns 200 for a project member (PI) deleting a donation on their project", async () => {
-      mockAuthenticateRequest.mockResolvedValueOnce(authenticatedUser); // userId 1, PI on project 1
+    test("DELETE /donations/{id} returns 200 for a project member (Director) deleting a donation on their project", async () => {
+      mockAuthenticateRequest.mockResolvedValueOnce(authenticatedUser); // userId 1, Director on project 1
       // donation_id 1 belongs to project_id 1
       const res = await handler(createEvent('DELETE', '/donations/1'));
       expect(res.statusCode).toBe(200);

--- a/apps/backend/lambdas/expenditures/handler.ts
+++ b/apps/backend/lambdas/expenditures/handler.ts
@@ -118,7 +118,7 @@ export const handler = async (event: any): Promise<APIGatewayProxyResult> => {
 
       const { projectID, amount, category, description, status, receiptUrl, spentOn } = validationResult;
 
-      // Authorize: must be global admin, or PI/Accountant/Admin on this project
+      // Authorize: must be global admin, or Director/Admin on this project
       if (!user.isAdmin) {
         const membership = await db
           .selectFrom('branch.project_memberships')
@@ -127,7 +127,7 @@ export const handler = async (event: any): Promise<APIGatewayProxyResult> => {
           .select('role')
           .executeTakeFirst();
 
-        if (!membership || !['PI', 'Accountant', 'Admin'].includes(membership.role)) {
+        if (!membership || !['Director', 'Admin'].includes(membership.role)) {
           return json(403, { message: 'Unable to create expenditure for this project' });
         }
       }
@@ -254,7 +254,7 @@ export const handler = async (event: any): Promise<APIGatewayProxyResult> => {
         return json(404, { message: 'Expenditure not found' });
       }
 
-      // (mirrors POST endpoint) Authorize: must be global admin, or PI/Accountant/Admin on this expenditure's project
+      // (mirrors POST endpoint) Authorize: must be global admin, or Director/Admin on this expenditure's project
       if (!user.isAdmin) {
         const membership = await db
           .selectFrom('branch.project_memberships')
@@ -263,7 +263,7 @@ export const handler = async (event: any): Promise<APIGatewayProxyResult> => {
           .select('role')
           .executeTakeFirst();
 
-        if (!membership || !['PI', 'Accountant', 'Admin'].includes(membership.role)) {
+        if (!membership || !['Director', 'Admin'].includes(membership.role)) {
           return json(403, { message: 'Unable to delete this expenditure' });
         }
       }

--- a/apps/backend/lambdas/expenditures/test/expenditures.e2e.test.ts
+++ b/apps/backend/lambdas/expenditures/test/expenditures.e2e.test.ts
@@ -85,33 +85,33 @@ const adminUser = {
   },
 };
 
-// Non-admin user 1: has PI role on project 1
-const piUser = {
+// Non-admin user 1: has Director role on project 1
+const directorUser = {
   isAuthenticated: true as const,
   user: {
-    cognitoSub: 'pi-sub',
+    cognitoSub: 'director-sub',
     userId: 1,
     email: 'ashley@branch.org',
     isAdmin: false,
   },
 };
 
-// Non-admin user 2: has Accountant role on project 1
-const accountantUser = {
+// Non-admin user 2: also has Director role on project 1
+const secondDirectorUser = {
   isAuthenticated: true as const,
   user: {
-    cognitoSub: 'accountant-sub',
+    cognitoSub: 'second-director-sub',
     userId: 2,
     email: 'renee@branch.org',
     isAdmin: false,
   },
 };
 
-// Non-admin user 3: has Staff role on project 2, no role on project 1
-const staffUser = {
+// Non-admin user 3: has Student role on project 2, no role on project 1
+const studentUser = {
   isAuthenticated: true as const,
   user: {
-    cognitoSub: 'staff-sub',
+    cognitoSub: 'student-sub',
     userId: 3,
     email: 'nour@branch.org',
     isAdmin: false,
@@ -205,31 +205,31 @@ describe('Expenditures integration tests', () => {
   });
 
   describe('Authorization', () => {
-    test('201: PI can create expenditure on their project', async () => {
-      mockAuthenticateRequest.mockResolvedValue(piUser);
+    test('201: Director can create expenditure on their project', async () => {
+      mockAuthenticateRequest.mockResolvedValue(directorUser);
 
       const res = await handler(postEvent({ projectID: 1, amount: 500 }));
       expect(res.statusCode).toBe(201);
     });
 
-    test('201: Accountant can create expenditure on their project', async () => {
-      mockAuthenticateRequest.mockResolvedValue(accountantUser);
+    test('201: a second Director on the same project can create expenditure', async () => {
+      mockAuthenticateRequest.mockResolvedValue(secondDirectorUser);
 
-      // User 2 is Accountant on project 1
+      // User 2 is also a Director on project 1
       const res = await handler(postEvent({ projectID: 1, amount: 750 }));
       expect(res.statusCode).toBe(201);
       expect(JSON.parse(res.body).body.enteredBy).toBe(2);
     });
 
-    test('403: Staff cannot create expenditure on their project', async () => {
-      mockAuthenticateRequest.mockResolvedValue(staffUser);
+    test('403: Student cannot create expenditure on their project', async () => {
+      mockAuthenticateRequest.mockResolvedValue(studentUser);
 
       const res = await handler(postEvent({ projectID: 2, amount: 500 }));
       expect(res.statusCode).toBe(403);
     });
 
     test('403: user with no membership on project is rejected', async () => {
-      mockAuthenticateRequest.mockResolvedValue(staffUser);
+      mockAuthenticateRequest.mockResolvedValue(studentUser);
 
       // User 3 has no membership on project 1
       const res = await handler(postEvent({ projectID: 1, amount: 500 }));
@@ -508,17 +508,17 @@ describe('Expenditures integration tests', () => {
       expect(body.body.projectId).toBe(1);
     });
 
-    test('403: staff with no membership on the project cannot read it', async () => {
-      mockAuthenticateRequest.mockResolvedValue(staffUser);
-      const id = await firstExpenditureId(1); // staffUser has no role on project 1
+    test('403: student with no membership on the project cannot read it', async () => {
+      mockAuthenticateRequest.mockResolvedValue(studentUser);
+      const id = await firstExpenditureId(1); // studentUser has no role on project 1
     
       const res = await handler(idRequestEvent('GET', id));
       expect(res.statusCode).toBe(403);
     });
     
-    test('200: staff can read an expenditure on a project they have a role on', async () => {
-      mockAuthenticateRequest.mockResolvedValue(staffUser);
-      const id = await firstExpenditureId(2); // staffUser is Staff on project 2
+    test('200: student can read an expenditure on a project they have a role on', async () => {
+      mockAuthenticateRequest.mockResolvedValue(studentUser);
+      const id = await firstExpenditureId(2); // studentUser is Student on project 2
     
       const res = await handler(idRequestEvent('GET', id));
       expect(res.statusCode).toBe(200);
@@ -545,26 +545,26 @@ describe('Expenditures integration tests', () => {
       expect(res.statusCode).toBe(404);
     });
 
-    test('403: Staff cannot delete an expenditure on a project they have no role on', async () => {
-      mockAuthenticateRequest.mockResolvedValue(staffUser);
-      const id = await firstExpenditureId(1); // staffUser has no membership on project 1
+    test('403: Student cannot delete an expenditure on a project they have no role on', async () => {
+      mockAuthenticateRequest.mockResolvedValue(studentUser);
+      const id = await firstExpenditureId(1); // studentUser has no membership on project 1
 
       const res = await handler(idRequestEvent('DELETE', id));
       expect(res.statusCode).toBe(403);
       expect(await expenditureExists(id)).toBe(true);
     });
 
-    test('403: Staff role on their own project is still not sufficient to delete', async () => {
-      mockAuthenticateRequest.mockResolvedValue(staffUser);
-      const id = await firstExpenditureId(2); // staffUser is Staff on project 2
+    test('403: Student role on their own project is still not sufficient to delete', async () => {
+      mockAuthenticateRequest.mockResolvedValue(studentUser);
+      const id = await firstExpenditureId(2); // studentUser is Student on project 2
 
       const res = await handler(idRequestEvent('DELETE', id));
       expect(res.statusCode).toBe(403);
       expect(await expenditureExists(id)).toBe(true);
     });
 
-    test('200: PI can delete an expenditure on their own project', async () => {
-      mockAuthenticateRequest.mockResolvedValue(piUser);
+    test('200: Director can delete an expenditure on their own project', async () => {
+      mockAuthenticateRequest.mockResolvedValue(directorUser);
       const id = await firstExpenditureId(1);
 
       const res = await handler(idRequestEvent('DELETE', id));
@@ -572,8 +572,8 @@ describe('Expenditures integration tests', () => {
       expect(await expenditureExists(id)).toBe(false);
     });
 
-    test('200: Accountant can delete an expenditure on their own project', async () => {
-      mockAuthenticateRequest.mockResolvedValue(accountantUser);
+    test('200: a second Director can delete an expenditure on their own project', async () => {
+      mockAuthenticateRequest.mockResolvedValue(secondDirectorUser);
       const id = await firstExpenditureId(1);
 
       const res = await handler(idRequestEvent('DELETE', id));
@@ -656,7 +656,7 @@ describe('Expenditures integration tests', () => {
     });
 
     test('403: non-admin user is rejected', async () => {
-      mockAuthenticateRequest.mockResolvedValue(staffUser);
+      mockAuthenticateRequest.mockResolvedValue(studentUser);
       const res = await handler(patchStatusEvent(1, { status: 'approved' }));
 
       expect(res.statusCode).toBe(403);

--- a/apps/backend/lambdas/expenditures/test/expenditures.unit.test.ts
+++ b/apps/backend/lambdas/expenditures/test/expenditures.unit.test.ts
@@ -66,14 +66,14 @@ function idEvent(method: 'GET' | 'DELETE', id: string) {
   };
 }
 
-const staffAuthContext = {
+const studentAuthContext = {
   isAuthenticated: true as const,
-  user: { cognitoSub: 'staff-sub', userId: 2, email: 'staff@example.com', isAdmin: false },
+  user: { cognitoSub: 'student-sub', userId: 2, email: 'student@example.com', isAdmin: false },
 };
 
-const piAuthContext = {
+const directorAuthContext = {
   isAuthenticated: true as const,
-  user: { cognitoSub: 'pi-sub', userId: 3, email: 'pi@example.com', isAdmin: false },
+  user: { cognitoSub: 'director-sub', userId: 3, email: 'director@example.com', isAdmin: false },
 };
 
 const fakeExpenditure = {
@@ -172,9 +172,9 @@ describe('POST /expenditures unit tests', () => {
       mockAuthenticateRequest.mockResolvedValue({
         isAuthenticated: true,
         user: {
-          cognitoSub: 'staff-sub',
+          cognitoSub: 'student-sub',
           userId: 2,
-          email: 'staff@example.com',
+          email: 'student@example.com',
           isAdmin: false,
         },
       });
@@ -202,23 +202,23 @@ describe('POST /expenditures unit tests', () => {
       expect(json.message).toContain('Unable to create expenditure');
     });
 
-    test('403: user with Staff role is rejected', async () => {
+    test('403: user with Student role is rejected', async () => {
       mockAuthenticateRequest.mockResolvedValue({
         isAuthenticated: true,
         user: {
-          cognitoSub: 'staff-sub',
+          cognitoSub: 'student-sub',
           userId: 2,
-          email: 'staff@example.com',
+          email: 'student@example.com',
           isAdmin: false,
         },
       });
 
-      // Mock: user has Staff role
+      // Mock: user has Student role
       mockDb.selectFrom.mockReturnValue({
         where: jest.fn().mockReturnValue({
           where: jest.fn().mockReturnValue({
             select: jest.fn().mockReturnValue({
-              executeTakeFirst: jest.fn().mockReturnValue({ role: 'Staff' } as any),
+              executeTakeFirst: jest.fn().mockReturnValue({ role: 'Student' } as any),
             }),
           }),
         }),
@@ -716,7 +716,7 @@ describe('GET /expenditures/{id} unit tests', () => {
 
   describe('Authorization', () => {
     test('403: non-admin with no project membership cannot read', async () => {
-      mockAuthenticateRequest.mockResolvedValue(staffAuthContext);
+      mockAuthenticateRequest.mockResolvedValue(studentAuthContext);
       mockDb.selectFrom
         .mockReturnValueOnce(mockSelectExpenditure(fakeExpenditure)) // expenditure lookup
         .mockReturnValueOnce(mockMembership(null)); // no membership row
@@ -727,10 +727,10 @@ describe('GET /expenditures/{id} unit tests', () => {
     });
 
     test('200: non-admin with membership on the project can read', async () => {
-      mockAuthenticateRequest.mockResolvedValue(staffAuthContext);
+      mockAuthenticateRequest.mockResolvedValue(studentAuthContext);
       mockDb.selectFrom
         .mockReturnValueOnce(mockSelectExpenditure(fakeExpenditure)) // expenditure lookup
-        .mockReturnValueOnce(mockMembership({ role: 'Staff' })); // has a role on the project
+        .mockReturnValueOnce(mockMembership({ role: 'Student' })); // has a role on the project
 
       const res = await handler(idEvent('GET', '5'));
       expect(res.statusCode).toBe(200);
@@ -811,7 +811,7 @@ describe('DELETE /expenditures/{id} unit tests', () => {
 
   describe('Authorization', () => {
     test('403: non-admin with no membership on the project', async () => {
-      mockAuthenticateRequest.mockResolvedValue(staffAuthContext);
+      mockAuthenticateRequest.mockResolvedValue(studentAuthContext);
       mockDb.selectFrom
         .mockReturnValueOnce(mockSelectExpenditure(fakeExpenditure)) // expenditure lookup
         .mockReturnValueOnce(mockMembership(null)); // no membership row
@@ -822,22 +822,22 @@ describe('DELETE /expenditures/{id} unit tests', () => {
       expect(mockDb.deleteFrom).not.toHaveBeenCalled();
     });
 
-    test('403: user with Staff role on the project is rejected', async () => {
-      mockAuthenticateRequest.mockResolvedValue(staffAuthContext);
+    test('403: user with Student role on the project is rejected', async () => {
+      mockAuthenticateRequest.mockResolvedValue(studentAuthContext);
       mockDb.selectFrom
         .mockReturnValueOnce(mockSelectExpenditure(fakeExpenditure))
-        .mockReturnValueOnce(mockMembership({ role: 'Staff' }));
+        .mockReturnValueOnce(mockMembership({ role: 'Student' }));
 
       const res = await handler(idEvent('DELETE', '5'));
       expect(res.statusCode).toBe(403);
     });
 
     test('membership check is scoped to the expenditure\'s own project_id, not the path id', async () => {
-      mockAuthenticateRequest.mockResolvedValue(piAuthContext);
+      mockAuthenticateRequest.mockResolvedValue(directorAuthContext);
       const membershipWhereProjectSpy = jest.fn().mockReturnValue({
         where: jest.fn().mockReturnValue({
           select: jest.fn().mockReturnValue({
-            executeTakeFirst: jest.fn().mockReturnValue({ role: 'PI' }),
+            executeTakeFirst: jest.fn().mockReturnValue({ role: 'Director' }),
           }),
         }),
       });
@@ -866,26 +866,26 @@ describe('DELETE /expenditures/{id} unit tests', () => {
       expect(json.pathParams).toEqual({ id: '5' });
     });
 
-    test('200: PI on the expenditure\'s project can delete', async () => {
-      mockAuthenticateRequest.mockResolvedValue(piAuthContext);
+    test('200: Director on the expenditure\'s project can delete', async () => {
+      mockAuthenticateRequest.mockResolvedValue(directorAuthContext);
       mockDb.selectFrom
         .mockReturnValueOnce(mockSelectExpenditure(fakeExpenditure))
-        .mockReturnValueOnce(mockMembership({ role: 'PI' }));
+        .mockReturnValueOnce(mockMembership({ role: 'Director' }));
       mockDb.deleteFrom.mockReturnValue(mockDelete(1n));
 
       const res = await handler(idEvent('DELETE', '5'));
       expect(res.statusCode).toBe(200);
     });
 
-    test('200: Accountant on the expenditure\'s project can delete', async () => {
-      const accountantAuthContext = {
+    test('200: a second Director on the expenditure\'s project can delete', async () => {
+      const secondDirectorAuthContext = {
         isAuthenticated: true as const,
-        user: { cognitoSub: 'acct-sub', userId: 4, email: 'acct@example.com', isAdmin: false },
+        user: { cognitoSub: 'second-director-sub', userId: 4, email: 'director2@example.com', isAdmin: false },
       };
-      mockAuthenticateRequest.mockResolvedValue(accountantAuthContext);
+      mockAuthenticateRequest.mockResolvedValue(secondDirectorAuthContext);
       mockDb.selectFrom
         .mockReturnValueOnce(mockSelectExpenditure(fakeExpenditure))
-        .mockReturnValueOnce(mockMembership({ role: 'Accountant' }));
+        .mockReturnValueOnce(mockMembership({ role: 'Director' }));
       mockDb.deleteFrom.mockReturnValue(mockDelete(1n));
 
       const res = await handler(idEvent('DELETE', '5'));
@@ -969,7 +969,7 @@ describe('PATCH /expenditures/{id}/status unit tests', () => {
   test('403: authenticated non-admin is rejected', async () => {
     mockAuthenticateRequest.mockResolvedValue({
       isAuthenticated: true,
-      user: { cognitoSub: 'staff-sub', userId: 2, email: 'staff@example.com', isAdmin: false },
+      user: { cognitoSub: 'student-sub', userId: 2, email: 'student@example.com', isAdmin: false },
     });
 
     const res = await handler(patchStatusEvent(5, { status: 'approved' }));

--- a/apps/backend/lambdas/projects/auth.ts
+++ b/apps/backend/lambdas/projects/auth.ts
@@ -58,7 +58,7 @@ export async function canEditProject(
 
     if (!membership) return false;
 
-    const editableRoles = ['PI', 'Accountant', 'Admin'];
+    const editableRoles = ['Director', 'Admin'];
     return editableRoles.includes(membership.role);
   } catch (error) {
     console.error('Error checking edit access:', error);
@@ -86,7 +86,7 @@ export async function canCreateProject(userId: number): Promise<boolean> {
  *
  * Deleting a project cascades to project_memberships, project_donations,
  * expenditures and reports (ON DELETE CASCADE, see db/migrations/), destroying
- * financial history. A PI may edit a project but must not be able to erase it.
+ * financial history. A Director may edit a project but must not be able to erase it.
  */
 export async function canDeleteProject(userId: number): Promise<boolean> {
   try {

--- a/apps/backend/lambdas/projects/test/delete-authz.unit.test.ts
+++ b/apps/backend/lambdas/projects/test/delete-authz.unit.test.ts
@@ -4,7 +4,7 @@
  * The route sat behind a stale "TODO: requireAuth needs to be added here once
  * ticket #241 is completed" long after #241 merged, so the handler's global gate
  * established authentication but nothing checked authorization: any authenticated
- * user — including a Staff member of an unrelated project — could delete any
+ * user — including a Student member of an unrelated project — could delete any
  * project, cascading away its memberships, donations, expenditures and reports.
  */
 import { describe, test, expect, beforeEach, jest } from '@jest/globals';

--- a/apps/backend/lambdas/projects/test/projects.e2e.test.ts
+++ b/apps/backend/lambdas/projects/test/projects.e2e.test.ts
@@ -21,7 +21,7 @@ const adminAuthResult = {
 
 const nonAdminAuthResult = {
   isAuthenticated: true as const,
-  user: { cognitoSub: 'staff-sub', userId: 3, email: 'nour@branch.org', isAdmin: false },
+  user: { cognitoSub: 'student-sub', userId: 3, email: 'nour@branch.org', isAdmin: false },
 };
 
 const pool = new Pool({
@@ -52,9 +52,9 @@ const nonMemberUser = {
   user: { cognitoSub: 'nonmember-sub', userId: 4, email: 'nonmember@branch.org', isAdmin: false },
 };
 
-const piMemberUser = {
+const directorMemberUser = {
   isAuthenticated: true as const,
-  user: { cognitoSub: 'pi-sub', userId: 5, email: 'pimember@branch.org', isAdmin: false },
+  user: { cognitoSub: 'director-sub', userId: 5, email: 'directormember@branch.org', isAdmin: false },
 };
 
 beforeEach(async () => {
@@ -118,11 +118,11 @@ describe('Authorization', () => {
       await client.query(
         `INSERT INTO branch.users (name, email, is_admin) VALUES
            ('Non Member', 'nonmember@branch.org', FALSE),
-           ('PI Member', 'pimember@branch.org', FALSE)`,
+           ('Director Member', 'directormember@branch.org', FALSE)`,
       );
       await client.query(
         `INSERT INTO branch.project_memberships (project_id, user_id, role, start_date, hours)
-         SELECT 1, user_id, 'PI', '2025-01-01', 10 FROM branch.users WHERE email = 'pimember@branch.org'`,
+         SELECT 1, user_id, 'Director', '2025-01-01', 10 FROM branch.users WHERE email = 'directormember@branch.org'`,
       );
     } finally {
       client.release();
@@ -151,7 +151,7 @@ describe('Authorization', () => {
   });
 
   test('200: member lists only projects they belong to', async () => {
-    mockAuthenticateRequest.mockResolvedValue(piMemberUser);
+    mockAuthenticateRequest.mockResolvedValue(directorMemberUser);
     const res = await handler(getEvent('/projects'));
     expect(res.statusCode).toBe(200);
     const body = JSON.parse(res.body);
@@ -173,22 +173,22 @@ describe('Authorization', () => {
     expect(JSON.parse(res.body).message).toBe('You do not have access to edit this project');
   });
 
-  test('200: PI member can read their project', async () => {
-    mockAuthenticateRequest.mockResolvedValue(piMemberUser);
+  test('200: Director member can read their project', async () => {
+    mockAuthenticateRequest.mockResolvedValue(directorMemberUser);
     const res = await handler(getEvent('/projects/1'));
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body).project_id).toBe(1);
   });
 
-  test('200: PI member can edit their project', async () => {
-    mockAuthenticateRequest.mockResolvedValue(piMemberUser);
-    const res = await handler(putEvent('/projects/1', { name: 'Renamed by PI' }));
+  test('200: Director member can edit their project', async () => {
+    mockAuthenticateRequest.mockResolvedValue(directorMemberUser);
+    const res = await handler(putEvent('/projects/1', { name: 'Renamed by Director' }));
     expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body).name).toBe('Renamed by PI');
+    expect(JSON.parse(res.body).name).toBe('Renamed by Director');
   });
 
-  test('403: PI member cannot edit a project they do not belong to', async () => {
-    mockAuthenticateRequest.mockResolvedValue(piMemberUser);
+  test('403: Director member cannot edit a project they do not belong to', async () => {
+    mockAuthenticateRequest.mockResolvedValue(directorMemberUser);
     const res = await handler(putEvent('/projects/2', { name: 'X' }));
     expect(res.statusCode).toBe(403);
   });

--- a/apps/frontend/src/types/project.ts
+++ b/apps/frontend/src/types/project.ts
@@ -9,7 +9,7 @@ export interface Project {
     created_at: string | null;
 };
 
-export type ProjectRole = 'PI' | 'Accountant' | 'Staff' | 'Admin';
+export type ProjectRole = 'Director' | 'Student' | 'Admin';
 
 export interface Member {
   user_id: number;


### PR DESCRIPTION
Project membership roles become **Admin**, **Director**, **Student**.

## Mapping

| Old | New |
| --- | --- |
| `Admin` | `Admin` |
| `PI` | `Director` |
| `Accountant` | `Director` |
| `Staff` | `Student` |

## Permissions are unchanged

`PI` and `Accountant` could both edit; `Staff` could not. So `editableRoles` collapses from `['PI', 'Accountant', 'Admin']` to `['Director', 'Admin']` and every existing authorization outcome is preserved. `Student` is read-only on expenditures, matching `Staff` today. The global `users.is_admin` flag and the frontend nav roles (`admin`/`standard`/`limited`) are a separate mechanism and are untouched.

## The migration is expand-only

`20260812011405_rename_project_roles.sql` widens the CHECK to old ∪ new **before** backfilling, so the currently deployed code can keep writing `'PI'`/`'Accountant'`/`'Staff'` during the window between the migration and the lambda deploy. A follow-up migration drops the three old names once this is live — it is the contract half and needs `-- allow-destructive:`.

One transient effect during that window: the still-deployed code checks `['PI','Accountant','Admin']`, so a backfilled `Director` row is denied *edit* (read is membership-only, so reads are unaffected) until the new lambdas land. Self-healing, no data impact.

## Verification

- `expenditures` — 107 tests pass (unit + e2e)
- `projects` — `projects.e2e` 28 pass, `delete-authz.unit` + `dashboard.unit` 13 pass
- `donors` — 50 pass; `health test 🌞` fails, but it fails identically on unmodified `main` (it fetches `localhost:3000/donors/health`, which needs the lambda container up)
- `apps/frontend` — `tsc --noEmit` clean
- Post-migration DB state: constraint is old ∪ new, rows are 2 `Director` / 1 `Student`

`shared/types/db-types.d.ts` is unchanged — `role` is still `VARCHAR(30)` → `string`, so the generated types can't drift.

## Left alone deliberately

The `Staff` headings in `ProjectCard.tsx` and `ProjectDetailClient.tsx` are generic labels for the whole member list, not the role — renaming them to "Students" would mislabel Directors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
