### PR TITLE
fix(ci): check out the repo in the lambda deploy job

### DIFF
--- a/.github/actions/slack-deploy/action.yml
+++ b/.github/actions/slack-deploy/action.yml
@@ -31,6 +31,12 @@ inputs:
     description: '(finalize mode) dir of <name>.meta ("name|outcome") files to decide pass/fail'
     required: false
     default: ''
+  force-failure:
+    description: >
+      (finalize mode) report failure regardless of results-dir. A .meta records one
+      step's outcome, so a job that dies after writing it still looks successful.
+    required: false
+    default: 'false'
   job-name:
     description: '(step mode) matrix job name to count completed legs for a live status bar'
     required: false
@@ -101,6 +107,7 @@ runs:
         DETAILS: ${{ inputs.details }}
         DETAILS_FILE: ${{ inputs.details-file }}
         RESULTS_DIR: ${{ inputs.results-dir }}
+        FORCE_FAILURE: ${{ inputs.force-failure }}
         JOB_NAME: ${{ inputs.job-name }}
         TS: ${{ inputs.ts }}
         DEPLOY_BY: ${{ inputs.deployed-by }}
@@ -308,7 +315,7 @@ runs:
           // read result artifacts to decide overall pass/fail, then complete/fail.
           if (mode === 'finalize') {
             const dir = process.env.RESULTS_DIR || '';
-            let anyFail = false;
+            let anyFail = process.env.FORCE_FAILURE === 'true';
             try {
               for (const m of fs.readdirSync(dir).filter(f => f.endsWith('.meta'))) {
                 const [, outcome] = fs.readFileSync(path.join(dir, m), 'utf8').trim().split('|');

--- a/.github/workflows/lambda-deploy.yml
+++ b/.github/workflows/lambda-deploy.yml
@@ -366,6 +366,11 @@ jobs:
       matrix:
         lambda: ${{ fromJson(needs.detect-changes.outputs.lambdas) }}
     steps:
+      # `Thread step (live)` below is a local composite action, so the repo has to
+      # be on disk. First, not last: checkout cleans the workspace and would wipe
+      # the downloaded zip.
+      - uses: actions/checkout@v4
+
       - name: Compute artifact name
         id: artifact
         run: echo "name=lambda-$(basename ${{ matrix.lambda }})" >> $GITHUB_OUTPUT
@@ -463,6 +468,9 @@ jobs:
           component: backend
           total-steps: ${{ needs.prep.outputs.total }}
           results-dir: lambda-results
+          # The artifacts only carry the aws-cli step's outcome, so a job that
+          # failed elsewhere would still finalize as a green deploy.
+          force-failure: ${{ needs.migrate.result == 'failure' || needs.deploy.result == 'failure' }}
           ts: ${{ needs.prep.outputs.ts }}
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes the `Lambda Deploy` failure on `feat(roles): project roles are Admin, Director, Student (#311)` ([run 31554276329](https://github.com/Code-4-Community/branch/actions/runs/31554276329)).

## What actually happened

The lambdas deployed fine. `Deploy lambda` was ✓ on all three of projects / expenditures / donors and `migrate` was ✓ — **the roles change is live in production.** The job died on the step *after* the deploy:

```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under
'/home/runner/work/branch/branch/.github/actions/slack-deploy'.
Did you forget to run actions/checkout before running your local action?
```

The `deploy` job's `Thread step (live)` uses the local composite action `./.github/actions/slack-deploy`, but the job never ran `actions/checkout`, so the action wasn't on disk. It is the only job in the repo that used the local action without checking out — `prep`, `migrate`, `notify`, `frontend-deploy` and all four `terraform-apply` jobs already do.

## Not a regression from #311

Every `Lambda Deploy` on `main` that actually shipped a lambda has failed this way since threaded notifications landed (#270):

| Run | Commit | Shape |
| --- | --- | --- |
| 31554276329 | #311 | `Deploy lambda` ✓, `Thread step (live)` ✗, Notify ✓ |
| 30598505113 | #290 | `Deploy lambda` ✓, `Thread step (live)` ✗, Notify ✓ |
| 30423381265 | dispatch | ✅ green — `migrations_only`, so `deploy` was **skipped** |

The only green run in that window is the one where the `deploy` job never ran. That's the tell.

## Why Slack said "complete" while GitHub went red

Separate bug, and the reason there was no failure notification. `finalize` decided pass/fail purely from the `lambda-result-*/*.meta` files, and those record `steps.deploy.outcome` — the aws-cli call, which succeeded. A job that dies *after* writing its `.meta` still finalized green. The Slack thread also stopped updating after `migrate`, because the per-lambda live steps are posted by the step that couldn't load.

So `finalize` gains a `force-failure` input, and `notify` passes it the actual job results.

## Changes

- `lambda-deploy.yml` — `actions/checkout@v4` as the **first** step of `deploy`. First, not last: checkout cleans the workspace and would wipe the downloaded `lambda.zip`.
- `slack-deploy/action.yml` — new optional `force-failure` input (default `'false'`), seeding `anyFail` in finalize mode.
- `lambda-deploy.yml` — `notify` passes `force-failure: ${{ needs.migrate.result == 'failure' || needs.deploy.result == 'failure' }}`.

## Verification

- `actionlint` (via Docker) — no findings on either changed file. The one repo-wide non-shellcheck finding is pre-existing, in `regenerate-db-types.yaml`.
- Both files parse as YAML; the embedded github-script body passes `node --check`.
- `deploy` step order confirmed: `checkout` → compute name → download artifact → creds → deploy.
- Finalize decision table exercised against real `.meta` files:

| `.meta` contents | `force-failure` | result |
| --- | --- | --- |
| all `success` (the shape of run 31554276329) | `true` | **FAIL** ✅ |
| all `success` | `false` | COMPLETE ✅ |
| `donors\|failure` | `false` | FAIL ✅ |
| `donors\|failure` | `true` | FAIL ✅ |

## Note for the reviewer

Merging this **won't** exercise the fix — `Lambda Deploy`'s `paths` filter is `apps/backend/lambdas/**`, `shared/types/**`, `apps/backend/db/migrations/**`, and this PR only touches `.github/**`. It gets validated on the next lambda merge, or by running the workflow manually with `migrations_only: false`.

`terraform-apply`'s `notify` has the same latent `.meta`-only blind spot, but it isn't broken today (all its jobs check out), so I left it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
