### PR TITLE
feat(expenses): admin_notes column and lambda S3 object permissions

### DIFF
--- a/.github/workflows/lambda-tests.yml
+++ b/.github/workflows/lambda-tests.yml
@@ -213,19 +213,25 @@ jobs:
           for f in $files; do
             [ -f "$f" ] || continue
             # '-- allow-destructive: <reason>' opts a file out, deliberately loudly.
+            # Read from the raw file: this opt-out is itself a comment.
             if grep -qi '^-- allow-destructive:' "$f"; then
               echo "::warning file=$f::opted out of the destructive-SQL check"
               continue
             fi
-            if grep -inE '\b(DROP[[:space:]]+SCHEMA|DROP[[:space:]]+DATABASE|TRUNCATE|DROP[[:space:]]+TABLE|DROP[[:space:]]+COLUMN)\b' "$f"; then
+            # Scan SQL, not prose. `make new-migration` scaffolds a header that
+            # says "CREATE INDEX CONCURRENTLY / VACUUM will not work here", and
+            # matching that failed every generated migration. Blanking comments
+            # rather than dropping the lines keeps grep -n line numbers honest.
+            sql=$(sed 's/--.*//' "$f")
+            if printf '%s\n' "$sql" | grep -inE '\b(DROP[[:space:]]+SCHEMA|DROP[[:space:]]+DATABASE|TRUNCATE|DROP[[:space:]]+TABLE|DROP[[:space:]]+COLUMN)\b'; then
               echo "::error file=$f::destructive statement. Migrations run against production BEFORE the new lambda code deploys, so the currently deployed code would hit the changed schema. See the expand/contract rules in apps/backend/db/README.md. Add '-- allow-destructive: <reason>' only for a contract-phase migration whose expand phase is already live."
               fail=1
             fi
-            if grep -inE 'CONCURRENTLY' "$f"; then
+            if printf '%s\n' "$sql" | grep -inE 'CONCURRENTLY'; then
               echo "::error file=$f::CONCURRENTLY cannot run inside a transaction, and the migrator wraps the run in one. This database is tiny -- use a plain CREATE INDEX."
               fail=1
             fi
-            if grep -inE '^[[:space:]]*INSERT[[:space:]]+INTO[[:space:]]+(branch\.)?users\b' "$f"; then
+            if printf '%s\n' "$sql" | grep -inE '^[[:space:]]*INSERT[[:space:]]+INTO[[:space:]]+(branch\.)?users\b'; then
               echo "::warning file=$f::inserting users in a migration puts rows in PRODUCTION. Seeded users with a NULL cognito_sub are claimable by POST /auth/register, so this can hand someone an account. Dev seed rows belong in apps/backend/db/seed.sql."
             fi
           done

--- a/apps/backend/db/migrations/20260812012951_add_expenditure_admin_notes.sql
+++ b/apps/backend/db/migrations/20260812012951_add_expenditure_admin_notes.sql
@@ -1,0 +1,16 @@
+-- add_expenditure_admin_notes
+--
+-- Every pending migration runs inside a SINGLE transaction, with
+-- search_path = branch, public -- so table names can be unqualified, and
+-- CREATE INDEX CONCURRENTLY / VACUUM will not work here.
+--
+-- This migration is applied to PRODUCTION automatically when the PR merges,
+-- BEFORE the new lambda code is deployed. It must be safe for the code that is
+-- live right now: additive changes only. See apps/backend/db/README.md for the
+-- expand/contract rules that destructive changes need.
+--
+-- Forward-only: there is no rollback. Fix a mistake with a new migration, and
+-- never edit a migration that has been merged -- someone has already run it.
+-- Do not use IF NOT EXISTS: you want a failure, not silent drift.
+
+ALTER TABLE expenditures ADD COLUMN admin_notes TEXT;

--- a/infrastructure/aws/README.md
+++ b/infrastructure/aws/README.md
@@ -49,6 +49,7 @@ No modules.
 | [aws_iam_role_policy.ci_plan_state_lock](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.ci_preview](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.lambda_cognito_admin](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.lambda_s3_objects](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy_attachment.ci_apply_admin](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ci_plan_readonly](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.lambda_basic](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/iam_role_policy_attachment) | resource |

--- a/infrastructure/aws/lambda.tf
+++ b/infrastructure/aws/lambda.tf
@@ -46,6 +46,27 @@ resource "aws_iam_role_policy" "lambda_cognito_admin" {
   })
 }
 
+# The expenditures lambda presigns receipt uploads and downloads. A presigned
+# URL carries the signer's permissions, so the role needs both PutObject and
+# GetObject or the browser's PUT/GET fails AccessDenied.
+resource "aws_iam_role_policy" "lambda_s3_objects" {
+  name = "branch-lambda-s3-objects"
+  role = aws_iam_role.lambda_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid    = "LambdaReportsBucketObjects"
+      Effect = "Allow"
+      Action = [
+        "s3:PutObject",
+        "s3:GetObject",
+      ]
+      Resource = "${aws_s3_bucket.reports_bucket.arn}/*"
+    }]
+  })
+}
+
 # Get AWS account ID for unique bucket naming
 data "aws_caller_identity" "current" {}
 

--- a/shared/types/db-types.d.ts
+++ b/shared/types/db-types.d.ts
@@ -30,6 +30,7 @@ export interface BranchDonors {
 }
 
 export interface BranchExpenditures {
+  admin_notes: string | null;
   amount: Numeric;
   category: string | null;
   created_at: Generated<Timestamp | null>;


### PR DESCRIPTION
Groundwork for the expense approve/deny flow, split out so it lands **before** the lambda code that depends on it. Migrations run against production before the new lambda code deploys, so this ordering is the required one.

## Migration

`20260812012951_add_expenditure_admin_notes.sql` adds a nullable `admin_notes TEXT` to `expenditures` — the reviewing admin's note. Additive and forward-only; safe for the lambda code that is live right now, which simply ignores the column.

`shared/types/db-types.d.ts` is regenerated to match, per the commit-them-together rule in `apps/backend/db/README.md`.

No status enum change was needed: the baseline check constraint already permits `needs_more_info`, which is the value the review UI writes.

## IAM

> [!IMPORTANT]
> The shared lambda role had **no S3 permissions at all**. A presigned URL carries the signer's permissions, so presigning a receipt upload would have failed `AccessDenied` at the browser's PUT.

Adds `s3:PutObject` / `s3:GetObject` scoped to `${aws_s3_bucket.reports_bucket.arn}/*`.

This overlaps in intent with #310, which adds the same two actions while making the bucket private. If #310 merges first this becomes a redundant second inline policy under a different name (`branch-lambda-s3-objects`) and can be dropped in review — the permissions are identical, so there is no ordering hazard either way.

Deliberately does **not** touch the bucket's public-access block or bucket policy — that is #310's change, and duplicating it here would conflict.

## CI guard bug

`migrations-guard` failed on this PR, and it turned out to be a bug in the guard rather than a problem with the migration.

`make new-migration` scaffolds a header containing the sentence:

```
-- CREATE INDEX CONCURRENTLY / VACUUM will not work here.
```

The guard grepped the **raw file**, so that sentence matched its own `CONCURRENTLY` check and the migration failed before it contained any SQL at all. Every migration generated by the project's own tooling would have failed this check. Nothing had tripped it yet because this is the first new migration since the guard landed — the only other file, `0000_baseline_schema.sql`, predates the template.

Fix: blank out SQL comments before the destructive / `CONCURRENTLY` / user-insert scans. Blanking rather than deleting the lines keeps `grep -n` line numbers pointing at the real line. The `-- allow-destructive:` opt-out still reads the raw file, since that marker is itself a comment.

Verified locally that the guard still catches genuine violations:

| Input | Result |
|---|---|
| this migration | pass |
| `CREATE INDEX CONCURRENTLY ...` in real SQL | **fail** (line 2) |
| `ALTER TABLE ... DROP COLUMN` under the scaffold header | **fail** (line 3) |
| `0000_baseline_schema.sql` | pass |

## Verification

`terraform fmt -check` clean; the terraform-docs job auto-committed the README row for the new IAM resource. `terraform validate` needs provider download and was not run.

Follow-up: the application PR is #315.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
