### PR TITLE
fix(preview): point preview lambdas at the branch RDS, not DBInstances[0]

### DIFF
--- a/.github/workflows/preview-env.yml
+++ b/.github/workflows/preview-env.yml
@@ -115,19 +115,29 @@ jobs:
             exit 1
           fi
 
-      # Build the preview lambdas' env from the ACTUAL prod config (single source
-      # of truth) + the live RDS endpoint. Reserved / credential keys are dropped;
-      # the module adds NODE_ENV. Only needed when creating the stack.
+      # Prod config is the single source of truth, DB_HOST included. Never re-derive
+      # it from `DBInstances[0]` -- this account hosts other C4C databases and that
+      # picked an unreachable one. Reserved / credential keys are dropped; the module
+      # adds NODE_ENV. Only needed when creating the stack.
       - name: Resolve preview lambda env
         if: steps.mode.outputs.create == 'true'
         run: |
-          DB_HOST=$(aws rds describe-db-instances --query "DBInstances[0].Endpoint.Address" --output text)
+          set -euo pipefail
           AUTH_ENV=$(aws lambda get-function-configuration --function-name branch-auth --query 'Environment.Variables' --output json)
           REPORTS_ENV=$(aws lambda get-function-configuration --function-name branch-reports --query 'Environment.Variables' --output json)
-          ENV_JSON=$(jq -n --argjson a "$AUTH_ENV" --argjson r "$REPORTS_ENV" --arg dbh "$DB_HOST" '
-            (($a // {}) + ($r // {}) + { "DB_HOST": $dbh })
+          ENV_JSON=$(jq -n --argjson a "$AUTH_ENV" --argjson r "$REPORTS_ENV" '
+            (($a // {}) + ($r // {}))
             | del(.NODE_ENV, .AWS_REGION, .AWS_DEFAULT_REGION, .AWS_ACCESS_KEY_ID, .AWS_SECRET_ACCESS_KEY, .AWS_SESSION_TOKEN)
           ')
+          # Fail loudly rather than shipping a preview that 401s on every DB call.
+          for key in DB_HOST DB_NAME DB_USER DB_PASSWORD COGNITO_USER_POOL_ID COGNITO_CLIENT_ID; do
+            value=$(jq -r --arg k "$key" '.[$k] // ""' <<<"$ENV_JSON")
+            if [ -z "$value" ]; then
+              echo "::error::branch-auth/branch-reports did not provide $key; preview lambdas would be misconfigured."
+              exit 1
+            fi
+          done
+          echo "Preview DB_HOST: $(jq -r '.DB_HOST' <<<"$ENV_JSON")"
           # Stash for the terraform step (multiline-safe).
           printf 'LAMBDA_ENV<<EOF\n%s\nEOF\n' "$ENV_JSON" >> "$GITHUB_ENV"
 

--- a/infrastructure/preview/variables.tf
+++ b/infrastructure/preview/variables.tf
@@ -4,9 +4,9 @@ variable "pr_number" {
 }
 
 # Full runtime environment for the preview lambdas, resolved by the workflow
-# from the ACTUAL prod lambda config (branch-auth + branch-reports) plus the
-# shared RDS endpoint. Passing it in keeps prod as the single source of truth
-# for DB creds / Cognito ids / reports bucket rather than duplicating them here.
+# from the ACTUAL prod lambda config (branch-auth + branch-reports). Passing it in
+# keeps prod as the single source of truth for DB_HOST / DB creds / Cognito ids /
+# reports bucket rather than duplicating -- or re-deriving -- them here.
 # Preview envs deliberately reuse the shared RDS + Cognito pool (data risk is
 # accepted); migrations are NEVER run from this module -- the generated DB types
 # hardcode the `branch.` schema prefix, so a per-PR schema would require per-PR

--- a/shared/lambda-auth/src/authenticate.ts
+++ b/shared/lambda-auth/src/authenticate.ts
@@ -49,39 +49,46 @@ export async function authenticateRequest(
   const token = extractToken(event);
   if (!token) return { isAuthenticated: false };
 
+  // Outside the try: missing config is a broken deployment, not a bad token.
+  const jwtVerifier = getVerifier();
+
+  let payload: any;
   try {
-    const payload = await getVerifier().verify(token);
-
-    const dbUser = await db
-      .selectFrom('branch.users')
-      .where('cognito_sub', '=', payload.sub)
-      .selectAll()
-      .executeTakeFirst();
-
-    if (!dbUser) {
-      console.warn(
-        'User authenticated with Cognito but not found in database:',
-        payload.sub,
-      );
-      return { isAuthenticated: false };
-    }
-
-    const user: AuthenticatedUser = {
-      cognitoSub: payload.sub,
-      userId: dbUser.user_id,
-      email: payload.email as string | undefined,
-      isAdmin: dbUser.is_admin === true,
-      // Informational only. We deliberately do NOT promote on a Cognito
-      // "Admins" group: branch.users.is_admin is the single source of truth.
-      // A second source would make demotion via PATCH /users/{userId} silently
-      // ineffective, nothing in this codebase writes group membership, and no
-      // aws_cognito_user_group is defined in infrastructure/aws/cognito.tf.
-      cognitoGroups: payload['cognito:groups'] as string[] | undefined,
-    };
-
-    return { user, isAuthenticated: true };
+    payload = await jwtVerifier.verify(token);
   } catch (error) {
+    // Only an unverifiable token is genuinely unauthenticated.
     console.error('Token verification failed:', error);
     return { isAuthenticated: false };
   }
+
+  // Uncaught on purpose: a DB outage is not a 401. Catching it hid an unreachable
+  // RDS behind "Authentication required" and logged users out. Handlers map to 500.
+  const dbUser = await db
+    .selectFrom('branch.users')
+    .where('cognito_sub', '=', payload.sub)
+    .selectAll()
+    .executeTakeFirst();
+
+  if (!dbUser) {
+    console.warn(
+      'User authenticated with Cognito but not found in database:',
+      payload.sub,
+    );
+    return { isAuthenticated: false };
+  }
+
+  const user: AuthenticatedUser = {
+    cognitoSub: payload.sub,
+    userId: dbUser.user_id,
+    email: payload.email as string | undefined,
+    isAdmin: dbUser.is_admin === true,
+    // Informational only. We deliberately do NOT promote on a Cognito
+    // "Admins" group: branch.users.is_admin is the single source of truth.
+    // A second source would make demotion via PATCH /users/{userId} silently
+    // ineffective, nothing in this codebase writes group membership, and no
+    // aws_cognito_user_group is defined in infrastructure/aws/cognito.tf.
+    cognitoGroups: payload['cognito:groups'] as string[] | undefined,
+  };
+
+  return { user, isAuthenticated: true };
 }

--- a/shared/lambda-auth/test/authenticate.test.ts
+++ b/shared/lambda-auth/test/authenticate.test.ts
@@ -197,34 +197,36 @@ describe('authenticateRequest', () => {
     expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ clientId: null }));
   });
 
-  it('degrades to unauthenticated (not a throw) when COGNITO_USER_POOL_ID is unset', async () => {
-    // This is why a missing env var manifests as blanket silent 401s across all
-    // six lambdas rather than a loud 500: getVerifier() throws inside the try.
+  it('throws (not a silent 401) when COGNITO_USER_POOL_ID is unset', async () => {
+    // Swallowing this gave blanket silent 401s across all six lambdas.
     delete process.env.COGNITO_USER_POOL_ID;
     const { authenticateRequest } = await loadModule();
     const { db } = makeDb({ user_id: 7, is_admin: true });
 
-    await expect(authenticateRequest(db, bearerEvent('good'))).resolves.toEqual({
-      isAuthenticated: false,
-    });
+    await expect(authenticateRequest(db, bearerEvent('good'))).rejects.toThrow(
+      'COGNITO_USER_POOL_ID',
+    );
     expect(mockCreate).not.toHaveBeenCalled();
   });
 
-  it('returns unauthenticated when the database query throws', async () => {
+  it('propagates a database failure instead of reporting it as unauthenticated', async () => {
+    // Regression guard for the preview-env outage (PR #316).
     mockVerify.mockResolvedValue({ sub: 'sub-1' });
     const { authenticateRequest } = await loadModule();
     const db = {
       selectFrom: () => ({
         where: () => ({
           selectAll: () => ({
-            executeTakeFirst: jest.fn().mockRejectedValue(new Error('db down')),
+            executeTakeFirst: jest
+              .fn()
+              .mockRejectedValue(new Error('timeout exceeded when trying to connect')),
           }),
         }),
       }),
     };
 
-    await expect(authenticateRequest(db, bearerEvent('good'))).resolves.toEqual({
-      isAuthenticated: false,
-    });
+    await expect(authenticateRequest(db, bearerEvent('good'))).rejects.toThrow(
+      'timeout exceeded when trying to connect',
+    );
   });
 });


### PR DESCRIPTION
## The bug

Auth failed in every preview environment while prod was fine. Multiple devs hit it. Symptom from the UI: login appears to work, then hangs ~11s and errors out.

`.github/workflows/preview-env.yml` resolved the preview lambdas' `DB_HOST` like this:

```bash
DB_HOST=$(aws rds describe-db-instances --query "DBInstances[0].Endpoint.Address" --output text)
```

This account hosts several unrelated C4C databases and the branch instance is **not** first:

| # | instance |
|---|---|
| 0 | `bhchp-postgres` ← what previews got |
| 1 | `c4c-hats` |
| 2 | `fcc-postgres` |
| 3 | `terraform-2025…001` ← the actual branch DB (prod uses this) |

So all 12 preview lambdas across PRs #302 and #310 pointed at another project's database, whose security group blackholes our traffic. Every query hit the 5s `connectionTimeoutMillis` in `db.ts` and threw.

## Why it looked like an auth bug

`authenticateRequest` wrapped both the JWT verification *and* the `branch.users` lookup in one `try/catch` that returned `isAuthenticated: false`. A dead database therefore surfaced as `401 Authentication required`.

That is also actively harmful beyond the bad diagnostics: the frontend treats 401 as an expired session, so `authedFetch` refreshes, retries, then calls `endSession()` — **a database blip logs the user out.**

Login and refresh kept working throughout because they only talk to Cognito and never touch the DB, which is exactly why this looked like "auth is broken" rather than "the DB is unreachable."

## Evidence

Against the PR-310 preview API, with a valid token:

| probe | before | after |
|---|---|---|
| `/auth/me`, real token | 401 in **5.06s / 5.12s / 5.58s** | **200 in 1.46s**, correct user |
| `/auth/me`, forged signature (real `kid`) | 401 in **165ms** | unchanged |
| `nc` to `bhchp-postgres:5432` | hangs (blackholed) | n/a |
| `nc` to branch RDS:5432 | 0.27s | n/a |

The forged-token probe is what isolated it: JWKS fetch and JWT verification were healthy and failed fast, so the 5s had to come from the line after `verify()`. `aws-jwt-verify`'s own timeouts (1500ms socket / 3000ms response) never matched 5.06s; `connectionTimeoutMillis: 5000` did, exactly.

## The fix

1. **`preview-env.yml`** — stop re-deriving `DB_HOST`. The prod lambda config the workflow already reads carries the right value, so inherit it like every other DB credential. Added a guard that fails the job if `DB_HOST` / DB creds / Cognito ids are missing, instead of silently shipping a preview that 401s on every call.
2. **`shared/lambda-auth/src/authenticate.ts`** — only catch token verification. DB errors and a missing `COGNITO_USER_POOL_ID` now propagate into the handlers' existing 500 mapping. No handler changes needed; they all already have an outer `catch` → `json(500, …)`.
3. Tests flipped to assert the new behavior. Two of them previously *documented* this footgun as intended — including the comment "This is why a missing env var manifests as blanket silent 401s across all six lambdas rather than a loud 500."

## Already applied out of band

The workflow only resolves lambda env on **label-add**, so the 12 already-created preview lambdas kept the bad `DB_HOST` regardless of this change. I repatched all of them to the branch RDS, which is what `infrastructure/preview/variables.tf` already documents as intended ("Preview envs deliberately reuse the shared RDS + Cognito pool"). PR-310's preview is working now — verified with the 200 above.

## Verification

- `shared/lambda-auth`: `npx jest` → **42/42 pass**; `npx tsc --noEmit` clean.
- `apps/backend/lambdas/auth`: 67 unit tests pass. 3 `auth.e2e.test.ts` failures are pre-existing — they need a lambda on `localhost:3000` and fail identically on clean `main`.
- Live: `/auth/me` on the PR-310 preview returns 200 with the correct user record.

## Follow-ups not in scope here

- Preview envs share the prod database and Cognito pool. That's a deliberate, documented tradeoff, but it means a preview can write to prod data.
- `apps/backend/lambdas/*/db.ts` duplicates the same Pool config six times, so the 5s timeout and TLS rules have to be kept in sync by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
