### PR TITLE
perf(db): index the foreign keys and list sort columns

### DIFF
--- a/apps/backend/db/migrations/20260812022651_add_access_pattern_indexes.sql
+++ b/apps/backend/db/migrations/20260812022651_add_access_pattern_indexes.sql
@@ -1,0 +1,75 @@
+-- 20260812022651_add_access_pattern_indexes
+--
+-- Every pending migration runs inside a SINGLE transaction, with
+-- search_path = branch, public -- so table names can be unqualified, and
+-- CREATE INDEX CONCURRENTLY / VACUUM will not work here.
+--
+-- This migration is applied to PRODUCTION automatically when the PR merges,
+-- BEFORE the new lambda code is deployed. It must be safe for the code that is
+-- live right now: additive changes only. See apps/backend/db/README.md for the
+-- expand/contract rules that destructive changes need.
+--
+-- Forward-only: there is no rollback. Fix a mistake with a new migration, and
+-- never edit a migration that has been merged -- someone has already run it.
+-- Do not use IF NOT EXISTS: you want a failure, not silent drift.
+--
+--
+-- Before this migration the schema had ELEVEN indexes, every one of them a
+-- primary key or a UNIQUE constraint, and not one on a foreign key. Postgres
+-- does not index a referencing column for you. So every lookup by project_id,
+-- every list ordered by a date, and every ON DELETE CASCADE was a sequential
+-- scan of the whole child table.
+--
+-- Adding an index is pure expand: it changes no column, breaks no live INSERT,
+-- and only ever makes the currently deployed code faster.
+--
+-- Indexes are written ASC even where the query sorts DESC. Both ORDER BY
+-- columns here are NOT NULL, so Postgres reads the same index backwards
+-- ("Index Scan Backward") and gets the ordering for free; a DESC index would
+-- buy nothing and only matters for mixed-direction multi-column sorts.
+
+-- expenditures.project_id -> the single hottest access path in the app.
+-- Serves the project-filtered expenditure list and its COUNT, the project
+-- detail page's expenditure tab, the report generator's expenditure section,
+-- and the FK check behind DELETE projects. Composite with spent_on because
+-- every one of those list queries also does ORDER BY spent_on DESC -- the
+-- second column turns a top-N sort over the whole table into an ordered walk
+-- of the matching rows only.
+CREATE INDEX expenditures_project_id_spent_on_idx
+    ON expenditures (project_id, spent_on);
+
+-- The unfiltered expenditure list (GET /expenditures with no projectId) sorts
+-- the entire table by spent_on to return one page. This is also the query
+-- behind the new admin approve/deny review queue, which fetches the list and
+-- filters to `pending` client-side -- so it pays the full sort on every open.
+CREATE INDEX expenditures_spent_on_idx
+    ON expenditures (spent_on);
+
+-- expenditures.entered_by is never filtered on directly, but it is a FK with
+-- ON DELETE SET NULL: deleting one user rewrote every matching row only after
+-- sequentially scanning all of expenditures to find them.
+CREATE INDEX expenditures_entered_by_idx
+    ON expenditures (entered_by);
+
+-- reports.project_id + date_created: same shape as expenditures -- filtered
+-- list, its COUNT, and the DELETE projects cascade, all sorted date_created
+-- DESC.
+CREATE INDEX reports_project_id_date_created_idx
+    ON reports (project_id, date_created);
+
+-- The unfiltered report list, sorted date_created DESC.
+CREATE INDEX reports_date_created_idx
+    ON reports (date_created);
+
+-- project_memberships.user_id. The UNIQUE constraint is (project_id, user_id),
+-- so it cannot serve a lookup keyed on user_id alone -- and that is exactly
+-- what GET /projects does for every non-admin user to find the projects they
+-- belong to. It is the landing page of the app. Also the DELETE users cascade.
+CREATE INDEX project_memberships_user_id_idx
+    ON project_memberships (user_id);
+
+-- project_donations.project_id. Same wrong-leading-column problem: UNIQUE is
+-- (donor_id, project_id). Serves GET /projects/{id}/donors, the report
+-- generator's donation section, and the DELETE projects cascade.
+CREATE INDEX project_donations_project_id_idx
+    ON project_donations (project_id);

--- a/apps/backend/lambdas/AGENTS.md
+++ b/apps/backend/lambdas/AGENTS.md
@@ -73,6 +73,10 @@ await db.selectFrom('branch.users').where('cognito_sub', '=', sub).selectAll().e
 await db.selectFrom('branch.users').select(db.fn.count('user_id').as('count')).executeTakeFirst();
 ```
 
+**Aggregate and filter in SQL, not in the lambda.** Pulling rows over the wire to sum, group or filter them in JS costs a full table scan that no index can fix, and it grows with the table. Use `db.fn.sum`/`db.fn.count` + `groupBy`, and push every filter into `where`. `GET /projects/dashboard` (`projects/handler.ts:83`) is the counter-example: it selects every expenditure row and buckets it by month in a JS loop.
+
+**Check your new query has an index.** Filter, join and `ORDER BY` columns need one — Postgres does not index foreign keys for you. `project_memberships` and `project_donations` in particular have UNIQUE constraints whose *leading* column is not the one most queries filter on, so those don't help. Add the index in the same PR (see `db/README.md`).
+
 ## Validation
 
 `projects` and `expenditures` have `validation-utils.ts` with static-method classes (`ProjectValidationUtils`, `ExpenditureValidationUtils`) returning either a `ValidationResult<T>` (`{ isValid, value?, error? }`) or an `Error` instance. Validate before DB writes; return `json(400, { message })` on failure. Integer params validated with `/^\d+$/` + positivity; dates with `/^\d{4}-\d{2}-\d{2}$/`.


### PR DESCRIPTION
## Why

The schema had **eleven indexes, and every one of them was a primary key or a UNIQUE constraint**. Not one covered a foreign key — Postgres doesn't create those for you.

That means every lookup by `project_id`, every date-ordered list page, and every `ON DELETE CASCADE` check was a sequential scan of the entire child table. This migration adds the seven indexes the code actually asks for.

## How the access patterns were determined

Full inventory of every query in `apps/backend/lambdas/*` and `shared/lambda-auth/`, plus the two open PRs (#310, #315) so this doesn't get invalidated the moment they merge.

Findings that shaped the index set:

- `project_memberships` and `project_donations` both have a UNIQUE constraint whose **leading column is the wrong one** for how they're queried. UNIQUE is `(project_id, user_id)` but `GET /projects` for a non-admin looks up by `user_id` alone — and that's the landing page of the app. Same story for `project_donations`: UNIQUE is `(donor_id, project_id)`, but everything filters on `project_id`.
- The authz lookups on `project_memberships` filter on **both** `project_id` and `user_id`, so the existing UNIQUE already serves them. No index needed there.
- `authenticate.ts:55` (`users WHERE cognito_sub = $1`) runs on *every authenticated request*, but `cognito_sub` is already UNIQUE. Nothing to do.
- The expenditure list queries all pair a `project_id` filter with `ORDER BY spent_on DESC`, hence the composite rather than a bare FK index — the second column removes the sort node entirely.

## Measurements

Local Postgres 16, schema built from the migrations in this repo, loaded with 500k expenditures / 50k memberships / 50k donations / 20k reports / 5k users / 2k projects. `EXPLAIN (ANALYZE, BUFFERS)`, warm cache. Buffer counts are the honest metric here — wall-clock on a warm local container flatters everything.

| Query | Before | After |
|---|---|---|
| Project-filtered expenditure page | 6846 buffers, 48.4 ms | **28 buffers, 0.8 ms** |
| Unfiltered expenditure page | 6846 buffers, 23.8 ms | **28 buffers, 1.2 ms** |
| `GET /projects` for a non-admin | 406 buffers, 6.2 ms | **34 buffers, 1.1 ms** |
| Project-filtered report page | 230 buffers, 7.8 ms | **15 buffers, 2.3 ms** |
| `GET /projects/{id}/donors` | 423 buffers, 7.4 ms | **82 buffers** |
| `DELETE` one project (FK cascade) | 179.2 ms | **42.0 ms** |
| `DELETE` one user (FK cascade) | 127.4 ms | **38.8 ms** |

The expenditure list went from reading ~53 MB per request to ~220 KB.

For the cascades, the time was almost entirely in one FK trigger: `expenditures_project_id_fkey` alone was 146 ms of the 179 ms project delete, and `expenditures_entered_by_fkey` was 108 ms of the 127 ms user delete.

## Cost

Seven indexes, **~11 MB total** at the row counts above. `expenditures` carries three of them, so its write path takes three extra index maintenance ops per insert — acceptable for a table that is read on nearly every page of the app and appended to a few times a day.

## Notes on what is deliberately *not* here

- **No index on `expenditures.status`.** The new admin review queue in #315 filters by status **client-side** — it fetches the list and narrows to `pending` in the browser. There is no SQL predicate on `status`, so an index (even a partial one) would never be used. If that filter moves server-side, `CREATE INDEX ... ON expenditures (status, spent_on) WHERE status = 'pending'` becomes worth adding; `pending` is a ~15% minority of rows, so a partial index would be well-targeted.
- **No index on `expenditures.category`.** The dashboard's two aggregates (`projects/handler.ts:75` and `:83`) are inherently full scans — one is a `GROUP BY project_id` over the whole table, and the other's `category IS NOT NULL` predicate matches ~100% of rows. Measured 86 ms and 51 ms, and **no index changes that.** `projects/handler.ts:83` streams every expenditure row into the Lambda and buckets it by month in a JS loop; that endpoint needs a server-side aggregate, not an index. Worth a follow-up issue.
- Indexes are declared **ASC even where queries sort DESC**. Both sort columns are `NOT NULL`, so Postgres reads the index backwards (`Index Scan Backward`) and gets the ordering for free — confirmed in the plans above. A `DESC` index would buy nothing.

## Safety

Adding an index is pure expand: no column changes, no live `INSERT` breaks, and the currently deployed code only gets faster. Satisfies the "safe for the code that is live right now" rule in `apps/backend/db/README.md`.

Plain `CREATE INDEX`, not `CONCURRENTLY` — the migrator wraps the run in a single transaction, and CI rejects `CONCURRENTLY` for that reason.

## Verification

- Applied all four migrations to an **empty** database in order — clean, as `migrations-fresh` does it.
- `seed.sql` applies on top of the migrated schema.
- Confirmed 11 → 18 indexes afterwards.
- Ran the `migrations-guard` filename regex and the destructive-SQL/`CONCURRENTLY` scan locally; both pass.
- No `shared/types/db-types.d.ts` change — indexes don't alter generated column types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
