### PR TITLE
fix(accounts): keep the sidebar on the accounts page

### DIFF
--- a/apps/frontend/src/app/accounts/page.tsx
+++ b/apps/frontend/src/app/accounts/page.tsx
@@ -1,25 +1,31 @@
 'use client';
 
 import React from 'react';
+import NavBar from '../components/Navbar';
 import StaffCard from '../components/StaffCard';
 import { facilitationTeam, teamMembers } from './mockUsers';
 
 export default function AccountsPage() {
     return (
-        <div className="!p-6">
-            <h1 className="![font-family:var(--font-heading)] !text-[length:var(--font-size-heading-1)] !font-semibold">Accounts</h1>
-            <h3 className="![font-family:var(--font-heading)] !text-[length:var(--font-size-heading-3)] !font-semibold">Core BRANCH Facilitation Team</h3>
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 !pt-3 !pb-7">
-                {facilitationTeam.map(user => (
-                    <StaffCard key={user.user_id} name={user.name} email={user.email} />
-                ))}
-            </div>
-            <h3 className="![font-family:var(--font-heading)] !text-[length:var(--font-size-heading-3)] !font-semibold">BRANCH Team Members</h3>
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 !pt-3 !pb-7">
-                {teamMembers.map(user => (
-                    <StaffCard key={user.user_id} name={user.name} email={user.email} />
-                ))}
-            </div>
+        <div style={{ display: 'flex', minHeight: '100vh' }}>
+            <NavBar />
+            <main style={{ flex: 1, backgroundColor: '#f9fafb' }}>
+                <div className="!p-6">
+                    <h1 className="![font-family:var(--font-heading)] !text-[length:var(--font-size-heading-1)] !font-semibold">Accounts</h1>
+                    <h3 className="![font-family:var(--font-heading)] !text-[length:var(--font-size-heading-3)] !font-semibold">Core BRANCH Facilitation Team</h3>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 !pt-3 !pb-7">
+                        {facilitationTeam.map(user => (
+                            <StaffCard key={user.user_id} name={user.name} email={user.email} />
+                        ))}
+                    </div>
+                    <h3 className="![font-family:var(--font-heading)] !text-[length:var(--font-size-heading-3)] !font-semibold">BRANCH Team Members</h3>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 !pt-3 !pb-7">
+                        {teamMembers.map(user => (
+                            <StaffCard key={user.user_id} name={user.name} email={user.email} />
+                        ))}
+                    </div>
+                </div>
+            </main>
         </div>
     );
 }

--- a/apps/frontend/test/components/AccountsPage.test.tsx
+++ b/apps/frontend/test/components/AccountsPage.test.tsx
@@ -33,4 +33,14 @@ describe('AccountsPage', () => {
             expect(cards?.length).toBeGreaterThan(0);
         }
     });
+
+    // Regression guard for #300: the accounts page is a signed-in app route, so
+    // it must keep the sidebar the way every other app page does. It used to
+    // render only its content with no NavBar, which stranded the user with no
+    // way to navigate away.
+    it('renders the sidebar so it persists on the accounts page', () => {
+        render(<AccountsPage />);
+        expect(screen.getByRole('navigation')).toBeInTheDocument();
+        expect(screen.getAllByText('BRANCH').length).toBeGreaterThan(0);
+    });
 });


### PR DESCRIPTION
This PR proposes restoring the persistent sidebar on the Accounts page (`/accounts`) so it no longer vanishes when you navigate there, matching the way every other signed-in page keeps it (`Fixes #300`). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/306. You can sign in with your GitHub ID to claim ownership of the project.

## What this fixes

Every signed-in app page — Donors, Donations, Expenses, Dashboard, Reports — wraps its content in a `display: flex` container with `<NavBar />` beside a `<main>`, so the green sidebar stays put as you move around. `apps/frontend/src/app/accounts/page.tsx` was the one exception: it returned only its `<div className="!p-6">` content and never rendered `<NavBar />`, so opening `/accounts` dropped the sidebar and left the user with no way to reach any other page. That is exactly what issue #300 reports ("The sidebar disappears, it should persist").

The fix wraps the existing accounts content in the same flex + `<NavBar />` + `<main>` layout the sibling pages use. The page's own markup is left untouched inside the `<main>`, so this is a purely additive structural change — no existing behavior or styling within the page moves.

## How I verified it

Reproduced on `main` (HEAD `1955c22`) with a test that renders the page and asserts the navigation landmark is present. On the current tree it fails, because there is no sidebar to find:

```
$ npx jest test/components/AccountsPage.test.tsx
● AccountsPage › renders the sidebar so it persists on the accounts page
  TestingLibraryElementError: Unable to find an accessible element with the role "navigation"
```

With the fix that test passes, and the full frontend suite stays green with no new failures against the pre-change baseline (baseline was 313 passed; this adds the one regression test). `tsc --noEmit` and `eslint` on the changed files are both clean:

```
$ npx jest
Test Suites: 31 passed, 31 total
Tests:       2 skipped, 314 passed, 316 total
```

The regression test lives beside the existing `AccountsPage` tests and fails without this change, so it guards the behavior going forward.

## Heads-up on overlap

Two open PRs (#302 and #303) also touch `apps/frontend/src/app/accounts/page.tsx` for unrelated reasons (an Add-User modal and real-API wiring). Neither adds the sidebar, so this change is complementary rather than competing — but whichever of us lands first will leave a small merge conflict in that file's outer JSX wrapper for the other. Happy to rebase onto whatever lands first.

## How this was managed

I imported your GitHub issues and pull requests into a live agile board (249 stories from your issues and PRs, 16 labels) and tracked this fix on the story for issue #300: https://eastagiletracker.com/projects/306/stories/200370 — part of the full board at https://eastagiletracker.com/projects/306.

![board](https://raw.githubusercontent.com/eastagiletracker/branch/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
