### PR TITLE
fix(frontend): mask the login password and let browsers save credentials

### DIFF
--- a/apps/frontend/src/app/components/SetPasswordForm.tsx
+++ b/apps/frontend/src/app/components/SetPasswordForm.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react';
 import TextInputField from './TextInputField';
+import ShowPasswordCheckbox from './ShowPasswordCheckbox';
 import { Button } from '@chakra-ui/react';
 
 /**
@@ -37,6 +38,7 @@ export default function SetPasswordForm({
   const [confirmPassword, setConfirmPassword] = useState('');
   const [newPasswordError, setNewPasswordError] = useState('');
   const [confirmPasswordError, setConfirmPasswordError] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
 
   function validate(): boolean {
     let valid = true;
@@ -58,13 +60,17 @@ export default function SetPasswordForm({
     return valid;
   }
 
-  async function handleSubmit() {
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
     if (!validate()) return;
     await onSubmit(newPassword);
   }
 
   return (
-    <div className="flex flex-col items-center text-center w-80">
+    <form
+      onSubmit={handleSubmit}
+      className="flex flex-col items-center text-center w-80"
+    >
       <h1 className="![font-family:var(--font-heading)] !text-[36px] !font-semibold !mb-6">
         {heading}
       </h1>
@@ -81,6 +87,9 @@ export default function SetPasswordForm({
           isError={!!newPasswordError}
           value={newPassword}
           onChange={(value) => setNewPassword(value)}
+          type={showPassword ? 'text' : 'password'}
+          name="new-password"
+          autoComplete="new-password"
         />
         <TextInputField
           label="Confirm Password *"
@@ -89,15 +98,23 @@ export default function SetPasswordForm({
           isError={!!confirmPasswordError}
           value={confirmPassword}
           onChange={(value) => setConfirmPassword(value)}
+          type={showPassword ? 'text' : 'password'}
+          name="confirm-password"
+          autoComplete="new-password"
+        />
+        <ShowPasswordCheckbox
+          checked={showPassword}
+          onChange={setShowPassword}
+          label="Show passwords"
         />
       </div>
       <Button
+        type="submit"
         className="![font-family:var(--font-body)] !rounded !bg-core-green !text-core-white w-full !px-4 !py-1.5 !mb-10"
-        onClick={handleSubmit}
         loading={isLoading}
       >
         {submitLabel}
       </Button>
-    </div>
+    </form>
   );
 }

--- a/apps/frontend/src/app/components/ShowPasswordCheckbox.tsx
+++ b/apps/frontend/src/app/components/ShowPasswordCheckbox.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { Checkbox } from '@chakra-ui/react';
+
+interface ShowPasswordCheckboxProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  /** Distinguishes the two checkboxes when a form has more than one. */
+  label?: string;
+}
+
+/**
+ * Toggles the masking on a password field. Shared so login and the
+ * set-password form stay identical.
+ */
+export default function ShowPasswordCheckbox({
+  checked,
+  onChange,
+  label = 'Show password',
+}: ShowPasswordCheckboxProps) {
+  return (
+    <Checkbox.Root
+      checked={checked}
+      onCheckedChange={(e) => onChange(!!e.checked)}
+      className="!self-start"
+      gap="2"
+    >
+      <Checkbox.HiddenInput />
+      <Checkbox.Control
+        borderRadius="sm"
+        css={{
+          backgroundColor: 'var(--color-core-white)',
+          borderColor: 'var(--color-core-green)',
+          '&[data-state="checked"]': {
+            backgroundColor: 'var(--color-primary-800)',
+            borderColor: 'var(--color-core-green)',
+          },
+        }}
+      />
+      <Checkbox.Label className="![font-family:var(--font-body)] !text-[14px] !font-normal !text-core-black">
+        {label}
+      </Checkbox.Label>
+    </Checkbox.Root>
+  );
+}

--- a/apps/frontend/src/app/components/TextInputField.tsx
+++ b/apps/frontend/src/app/components/TextInputField.tsx
@@ -20,6 +20,11 @@ interface TextInputFieldProps {
   /** Rendered before the value, e.g. `$` on the budget field. */
   prefix?: string;
   inputMode?: 'text' | 'decimal' | 'numeric';
+  /** `password` masks the value; the caller flips it to `text` to reveal. */
+  type?: 'text' | 'email' | 'password';
+  /** Both are needed for browsers to recognise and offer to save credentials. */
+  name?: string;
+  autoComplete?: string;
 }
 
 export default function TextInputField({
@@ -36,6 +41,9 @@ export default function TextInputField({
   rows = 4,
   prefix,
   inputMode,
+  type = 'text',
+  name,
+  autoComplete,
 }: TextInputFieldProps) {
   const [internalValue, setInternalValue] = useState('');
 
@@ -104,6 +112,9 @@ export default function TextInputField({
             placeholder={placeholder}
             disabled={disabled}
             inputMode={inputMode}
+            type={type}
+            name={name}
+            autoComplete={autoComplete}
           />
         </div>
       )}

--- a/apps/frontend/src/app/login/page.tsx
+++ b/apps/frontend/src/app/login/page.tsx
@@ -3,6 +3,7 @@
 import React, { Suspense, useState } from 'react';
 import TextInputField from '../components/TextInputField';
 import SetPasswordForm from '../components/SetPasswordForm';
+import ShowPasswordCheckbox from '../components/ShowPasswordCheckbox';
 import Link from 'next/link';
 import { Button } from '@chakra-ui/react';
 import { useAuth, type LoginResult } from '@/context/AuthContext';
@@ -30,6 +31,7 @@ function LoginPageContent() {
     const [passwordError, setPasswordError] = useState('');
     const [formError, setFormError] = useState('');
     const [isLoading, setIsLoading] = useState(false);
+    const [showPassword, setShowPassword] = useState(false);
 
     // 'credentials' -> optionally 'newPassword'. Adding a TOTP step later is one
     // more value here and one more case in handleResult — the context already
@@ -105,6 +107,13 @@ function LoginPageContent() {
         }
     }
 
+    // Submitting a real form — rather than clicking a bare button — is what lets
+    // the browser offer to save the credentials.
+    async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+        e.preventDefault();
+        await handleLogin();
+    }
+
     async function handleNewPassword(newPassword: string) {
         if (!challenge) return;
         setFormError('');
@@ -139,7 +148,7 @@ function LoginPageContent() {
 
     return (
         <div className="flex min-h-screen items-center justify-center px-4">
-        <div className="flex flex-col items-center text-center w-80">
+        <form onSubmit={handleSubmit} className="flex flex-col items-center text-center w-80">
             <h1 className="![font-family:var(--font-heading)] !text-[36px] !font-semibold !mb-6">Login</h1>
             <h5 className="![font-family:var(--font-body)] !text-[16px] !font-bold !mb-6">BRANCH Accounting Platform</h5>
             {formError && (
@@ -155,6 +164,9 @@ function LoginPageContent() {
                     isError={!!emailError}
                     value={email}
                     onChange={(value) => setEmail(value)}
+                    type="email"
+                    name="email"
+                    autoComplete="username"
                 />
                 <TextInputField
                     label="Password *"
@@ -163,11 +175,15 @@ function LoginPageContent() {
                     isError={!!passwordError}
                     value={password}
                     onChange={(value) => setPasswordValue(value)}
+                    type={showPassword ? 'text' : 'password'}
+                    name="password"
+                    autoComplete="current-password"
                 />
+                <ShowPasswordCheckbox checked={showPassword} onChange={setShowPassword} />
             </div>
             <Button
+                type="submit"
                 className="![font-family:var(--font-body)] !rounded !bg-core-green !text-core-white w-full !px-4 !py-1.5 !mb-10"
-                onClick={handleLogin}
                 loading={isLoading}
             >
                 Login
@@ -175,7 +191,7 @@ function LoginPageContent() {
             <Link href="/forgot-password" className="!text-core-green !font-bold ![font-family:var(--font-body)] !text-[16px]">
                 Forgot password?
             </Link>
-        </div>
+        </form>
         </div>
     );
 }

--- a/apps/frontend/test/components/LoginPage.test.tsx
+++ b/apps/frontend/test/components/LoginPage.test.tsx
@@ -62,6 +62,41 @@ describe('Login Page Component', () => {
             expect(screen.getByPlaceholderText('Enter password')).toBeInTheDocument();
         });
 
+        it('masks the password and labels both fields for password managers', () => {
+            // Without type=password plus these autocomplete hints the browser
+            // neither hides the value nor offers to save the credentials.
+            render(<LoginPage />);
+            const email = screen.getByPlaceholderText('Enter email address');
+            const password = screen.getByPlaceholderText('Enter password');
+
+            expect(password).toHaveAttribute('type', 'password');
+            expect(password).toHaveAttribute('autocomplete', 'current-password');
+            expect(email).toHaveAttribute('autocomplete', 'username');
+        });
+
+        it('submits a real form, which is what triggers the save-password prompt', () => {
+            render(<LoginPage />);
+            expect(
+                screen.getByPlaceholderText('Enter password').closest('form'),
+            ).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: 'Login' })).toHaveAttribute(
+                'type',
+                'submit',
+            );
+        });
+
+        it('unmasks the password while "Show password" is checked', async () => {
+            render(<LoginPage />);
+            const password = screen.getByPlaceholderText('Enter password');
+            const toggle = screen.getByRole('checkbox', { name: /show password/i });
+
+            await userEvent.click(toggle);
+            expect(password).toHaveAttribute('type', 'text');
+
+            await userEvent.click(toggle);
+            expect(password).toHaveAttribute('type', 'password');
+        });
+
         it('renders the login button', () => {
             render(<LoginPage />);
             expect(screen.getByRole('button', { name: 'Login' })).toBeInTheDocument();


### PR DESCRIPTION
## What

The login page rendered its password field with the default `type="text"`, so the value was visible on screen and no password manager recognised it as a credential. There was also no `<form>` — the Login button was a bare `onClick`, and browsers only offer to save credentials on a form submission.

## Changes

- **`TextInputField`** — added `type` / `name` / `autoComplete` passthroughs to the underlying `Input`.
- **`login/page.tsx`** — wrapped in a real `<form onSubmit>` with a `type="submit"` button. Email is tagged `autocomplete="username"`, password is `type="password"` + `autocomplete="current-password"`.
- **`ShowPasswordCheckbox`** — new shared component, styled off the existing `DataTable` checkbox tokens.
- **`SetPasswordForm`** — the same bug affected login step 2 (`NEW_PASSWORD_REQUIRED`) and `/reset-password`, so both fields now mask, share the toggle, and use `autocomplete="new-password"`.

## Testing

- 3 new tests in `LoginPage.test.tsx`: masking + autocomplete attributes, form/submit wiring, and the toggle flipping the input type.
- `npx jest` — 33 suites, 325 passed.
- `tsc --noEmit` and `eslint` clean.
- Verified in Chrome against the dev server: the password renders as dots and "Show password" reveals it.

## Note

Branched off `origin/main`, not `feat/projects-figma`. That branch has a cosmetic rename (`setPasswordValue` → `setPassword`) and a dropped `console.error` on the same login-page lines, so expect a small conflict if both land together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
