### PR TITLE
329 Update Expenses Page

### DIFF
--- a/apps/frontend/src/app/components/AddExpenseModal.tsx
+++ b/apps/frontend/src/app/components/AddExpenseModal.tsx
@@ -8,6 +8,12 @@ import FileUpload from './FileUpload';
 import { FiDollarSign } from 'react-icons/fi';
 import { getReceiptUploadUrl, uploadReceiptToS3 } from '@/lib/expenditures';
 import { Project } from '@/types';
+
+function formatAmountDisplay(digits: string): string {
+  if (!digits) return '';
+  const trimmed = digits.replace(/^0+(?=\d)/, '');
+  return trimmed.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+}
 interface AddExpenseModalProps {
   open: boolean;
   onClose: () => void;
@@ -28,7 +34,7 @@ export default function AddExpenseModal({
   const [newDate, setNewDate] = useState('');
   const [newType, setNewType] = useState('');
   const [newDescription, setNewDescription] = useState('');
-  const [newAmount, setNewAmount] = useState('');
+  const [amountDigits, setAmountDigits] = useState('');
   const [newProject, setNewProject] = useState('');
   const [newFile, setNewFile] = useState<File | null>(null);
   const [receiptUrl, setReceiptUrl] = useState<string | null>(null);
@@ -41,11 +47,21 @@ export default function AddExpenseModal({
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [fileError, setFileError] = useState<string | null>(null);
 
+  const amount = amountDigits ? Number(amountDigits) : 0;
+  
+  const isFormValid =
+    newDate.trim().length > 0 &&
+    newType.trim().length > 0 &&
+    newDescription.trim().length > 0 &&
+    amountDigits.length > 0 &&
+    amount > 0 &&
+    newProject.trim().length > 0;
+
   function resetForm() {
     setNewDate('');
     setNewType('');
     setNewDescription('');
-    setNewAmount('');
+    setAmountDigits('');
     setNewProject('');
     setNewFile(null);
     setReceiptUrl(null);
@@ -84,7 +100,7 @@ export default function AddExpenseModal({
     const hasDateError = !newDate.trim();
     const hasTypeError = !newType.trim();
     const hasDescError = !newDescription.trim();
-    const hasAmountError = !newAmount.trim() || isNaN(Number(newAmount)) || Number(newAmount) < 0;
+    const hasAmountError = !amountDigits || amount <= 0;
     const hasProjectError = !newProject.trim();
     const hasFileError = !newFile || !receiptUrl;
 
@@ -106,7 +122,7 @@ export default function AddExpenseModal({
     try {
       await api.post('/expenditures', {
         projectID: selectedProject.project_id,
-        amount: Number(newAmount),
+        amount,
         category: newType,
         description: newDescription,
         spentOn: newDate,
@@ -219,12 +235,12 @@ export default function AddExpenseModal({
                         <FiDollarSign size={20} strokeWidth={2.5}/>
                       </span>
                       <input
-                        type="number"
-                        min="0"
-                        step="0.01"
-                        value={newAmount}
+                        type="text"
+                        inputMode="numeric"
+                        value={formatAmountDisplay(amountDigits)}
                         onChange={(e) => {
-                          setNewAmount(e.target.value);
+                          const digitsOnly = e.target.value.replace(/\D/g, '');
+                          setAmountDigits(digitsOnly.slice(0, 9));
                           setAmountError(false);
                         }}
                         placeholder="Enter the Amount"
@@ -292,11 +308,13 @@ export default function AddExpenseModal({
                   <textarea
                     value={newDescription}
                     onChange={(e) => {
+                      if (e.target.value.length > 500) return;
                       setNewDescription(e.target.value);
                       setDescError(false);
                     }}
                     placeholder="Placeholder"
                     rows={4}
+                    maxLength={500}
                     style={{
                       border: `1px solid ${descError ? 'var(--color-error-red)' : 'var(--color-black-200)'}`,
                       borderRadius: '6px',
@@ -305,9 +323,12 @@ export default function AddExpenseModal({
                       outline: 'none',
                       width: '100%',
                       fontFamily: 'inherit',
-                      resize: 'vertical',
+                      resize: 'none',
                     }}
                   />
+                  <span style={{ fontSize: '12px', color: 'var(--color-black-500)', textAlign: 'right' }}>
+                    {newDescription.length}/500
+                  </span>
                   {descError && (
                     <span style={{ color: 'var(--color-error-red)', fontSize: '12px' }}>
                       Enter a description
@@ -353,9 +374,11 @@ export default function AddExpenseModal({
                 Cancel
               </Button>
               <Button
-                backgroundColor="var(--color-core-green)"
+                backgroundColor={isFormValid ? 'var(--color-core-green)' : 'var(--color-primary-500)'}
                 color="var(--color-core-white)"
+                disabled={!isFormValid}
                 onClick={handleSubmit}
+                cursor={isFormValid ? 'pointer' : 'not-allowed'}
               >
                 Submit For Review
               </Button>

--- a/apps/frontend/src/app/components/DropdownSelector.tsx
+++ b/apps/frontend/src/app/components/DropdownSelector.tsx
@@ -95,8 +95,7 @@ export default function DropdownSelector({
 
         <Portal>
           <Select.Positioner style={{ width: 'var(--reference-width)', left:"3px" }}>
-            <Select.Content className="!rounded !border !border-black-200 !bg-core-white !shadow-none !p-0 !mt-0.5 !font-body !text-body">
-              {collection.items.map((item) =>
+          <Select.Content className="!rounded !border !border-black-200 !bg-core-white !shadow-none !p-0 !mt-0.5 !font-body !text-body !max-h-[176px] !overflow-y-auto">              {collection.items.map((item) =>
                 multiSelect ? (
                   <Select.Item
                     key={item.value}

--- a/apps/frontend/test/components/AddExpenseModal.test.tsx
+++ b/apps/frontend/test/components/AddExpenseModal.test.tsx
@@ -71,6 +71,28 @@ const baseProps = {
   ],
 };
 
+// Fills every required field so the Submit button becomes enabled. Kept as a
+// shared helper since several tests need a fully valid form before they can
+// even click Submit — the button is disabled until then.
+function fillValidForm() {
+  fireEvent.change(document.querySelector('input[type="date"]')!, {
+    target: { value: '2025-05-15' },
+  });
+  fireEvent.change(screen.getByPlaceholderText('Enter the Amount'), {
+    target: { value: '12000' },
+  });
+  fireEvent.change(screen.getByLabelText('Select type'), {
+    target: { value: 'Travel Foreign' },
+  });
+  fireEvent.change(screen.getByLabelText('Select a project'), {
+    target: { value: 'Project Name 2' },
+  });
+  fireEvent.change(screen.getByPlaceholderText('Placeholder'), {
+    target: { value: 'A test description' },
+  });
+  fireEvent.click(screen.getByText('mock-select-file'));
+}
+
 beforeEach(() => {
   jest.clearAllMocks();
 });
@@ -107,19 +129,50 @@ describe('AddExpenseModal Component', () => {
     expect(screen.getByText('Submit For Review')).toBeInTheDocument();
   });
 
-  it('shows validation errors when submitting an empty form', () => {
+  // Replaces the old "shows validation errors when submitting an empty form"
+  // test. Submit is now disabled until the form is valid, so a click on an
+  // empty form never reaches handleSubmit — there is nothing for it to
+  // validate. The disabled state itself is the assertion now.
+  it('disables the Submit button when the form is empty', () => {
     render(<AddExpenseModal {...baseProps} />);
-    fireEvent.click(screen.getByText('Submit For Review'));
-  
-    expect(screen.getByText('Enter a valid amount')).toBeInTheDocument();
-    expect(screen.getByText('Select a type of expense')).toBeInTheDocument();
-    expect(screen.getByText('Select a project')).toBeInTheDocument();
-    expect(screen.getByText('Enter a description')).toBeInTheDocument();
-    expect(screen.getByText('Please upload an image of the receipt')).toBeInTheDocument();
+    expect(screen.getByText('Submit For Review')).toBeDisabled();
+  });
+
+  it('keeps the Submit button disabled until date, amount, type, project, and description are filled', () => {
+    render(<AddExpenseModal {...baseProps} />);
+
+    fireEvent.change(document.querySelector('input[type="date"]')!, {
+      target: { value: '2025-05-15' },
+    });
+    expect(screen.getByText('Submit For Review')).toBeDisabled();
+
+    fireEvent.change(screen.getByPlaceholderText('Enter the Amount'), {
+      target: { value: '12000' },
+    });
+    expect(screen.getByText('Submit For Review')).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText('Select type'), {
+      target: { value: 'Travel Foreign' },
+    });
+    expect(screen.getByText('Submit For Review')).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText('Select a project'), {
+      target: { value: 'Project Name 2' },
+    });
+    expect(screen.getByText('Submit For Review')).toBeDisabled();
+
+    // The receipt is intentionally not part of isFormValid, so the button
+    // enables here, before any file is selected.
+    fireEvent.change(screen.getByPlaceholderText('Placeholder'), {
+      target: { value: 'A test description' },
+    });
+    expect(screen.getByText('Submit For Review')).not.toBeDisabled();
   });
 
   it('does not call apiFetch when the form is invalid', () => {
     render(<AddExpenseModal {...baseProps} />);
+    // Submit is disabled while the form is empty, so this click is a no-op —
+    // asserting apiFetch was never reached either way.
     fireEvent.click(screen.getByText('Submit For Review'));
     expect(apiFetch).not.toHaveBeenCalled();
   });
@@ -128,23 +181,7 @@ describe('AddExpenseModal Component', () => {
     (apiFetch as jest.Mock).mockResolvedValueOnce({});
     render(<AddExpenseModal {...baseProps} />);
 
-    fireEvent.change(document.querySelector('input[type="date"]')!, {
-      target: { value: '2025-05-15' },
-    });
-    fireEvent.change(screen.getByPlaceholderText('Enter the Amount'), {
-      target: { value: '12000' },
-    });
-    fireEvent.change(screen.getByLabelText('Select type'), {
-      target: { value: 'Travel Foreign' },
-    });
-    fireEvent.change(screen.getByLabelText('Select a project'), {
-      target: { value: 'Project Name 2' },
-    });
-    fireEvent.change(screen.getByPlaceholderText('Placeholder'), {
-      target: { value: 'A test description' },
-    });
-    fireEvent.click(screen.getByText('mock-select-file'));
-
+    fillValidForm();
     fireEvent.click(screen.getByText('Submit For Review'));
 
     await waitFor(() => {
@@ -169,22 +206,7 @@ describe('AddExpenseModal Component', () => {
     (apiFetch as jest.Mock).mockResolvedValueOnce({});
     render(<AddExpenseModal {...baseProps} />);
 
-    fireEvent.change(document.querySelector('input[type="date"]')!, {
-      target: { value: '2025-05-15' },
-    });
-    fireEvent.change(screen.getByPlaceholderText('Enter the Amount'), {
-      target: { value: '12000' },
-    });
-    fireEvent.change(screen.getByLabelText('Select type'), {
-      target: { value: 'Travel Foreign' },
-    });
-    fireEvent.change(screen.getByLabelText('Select a project'), {
-      target: { value: 'Project Name 2' },
-    });
-    fireEvent.change(screen.getByPlaceholderText('Placeholder'), {
-      target: { value: 'A test description' },
-    });
-    fireEvent.click(screen.getByText('mock-select-file'));
+    fillValidForm();
     fireEvent.click(screen.getByText('Submit For Review'));
 
     await waitFor(() => {
@@ -196,22 +218,7 @@ describe('AddExpenseModal Component', () => {
     (apiFetch as jest.Mock).mockRejectedValueOnce(new Error('Server exploded'));
     render(<AddExpenseModal {...baseProps} />);
 
-    fireEvent.change(document.querySelector('input[type="date"]')!, {
-      target: { value: '2025-05-15' },
-    });
-    fireEvent.change(screen.getByPlaceholderText('Enter the Amount'), {
-      target: { value: '12000' },
-    });
-    fireEvent.change(screen.getByLabelText('Select type'), {
-      target: { value: 'Travel Foreign' },
-    });
-    fireEvent.change(screen.getByLabelText('Select a project'), {
-      target: { value: 'Project Name 2' },
-    });
-    fireEvent.change(screen.getByPlaceholderText('Placeholder'), {
-      target: { value: 'A test description' },
-    });
-    fireEvent.click(screen.getByText('mock-select-file'));
+    fillValidForm();
     fireEvent.click(screen.getByText('Submit For Review'));
 
     await waitFor(() => {


### PR DESCRIPTION
### ℹ️ Issue

Closes #329 

### 📝 Description

Updated the expenses page to match the new figma designs

Briefly list the changes made to the code:
1. Made the 'add expense' button disabled until all fields filled out
2. Ensure that the input for the amount field is a number
3. The description is capped at 500 characters
4. If more than 4 projects available, a scrollbar will appear in the dropdown selector

### ✔️ Verification

What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves.

Provide screenshots of any new components, styling changes, or pages. 
Jest tests:
<img width="1162" height="531" alt="Screenshot 2026-08-22 230746" src="https://github.com/user-attachments/assets/f00b63df-3a43-4ec7-92fb-a2a4769dc7eb" />
Modal has description capped at 500 characters & the button is disabled when fields aren't filled out:
<img width="911" height="1164" alt="Screenshot 2026-08-22 230810" src="https://github.com/user-attachments/assets/1bb23656-aee7-4d6f-9e02-9ffa10c26415" />


### 🏕️ (Optional) Future Work / Notes

Did you notice anything ugly during the course of this ticket? Any bugs, design challenges, or unexpected behavior? Write it down so we can clean it up in a future ticket!
