### PR TITLE
feat(infra): tag all AWS resources Project=branch + name the RDS instance

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -76,8 +76,9 @@ jobs:
             # Derive unique directories from changed files on push.
             # Exclude infrastructure/preview: it's the per-PR module (needs a
             # pr_number, applied per-PR by preview-env.yml). preview-shared is
-            # applied normally here.
-            echo "$ALL_CHANGED" | tr ' ' '\n' | xargs -I {} dirname {} | sort -u | grep -vx 'infrastructure/preview' | jq -R -s -c 'split("\n") | map(select(length > 0))' > dirs.json
+            # applied normally here. Exclude infrastructure/modules/*: shared
+            # child modules with no backend, applied via their callers.
+            echo "$ALL_CHANGED" | tr ' ' '\n' | xargs -I {} dirname {} | sort -u | grep -vx 'infrastructure/preview' | grep -v '^infrastructure/modules/' | jq -R -s -c 'split("\n") | map(select(length > 0))' > dirs.json
             dirs_json=$(cat dirs.json)
           fi
 

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -54,11 +54,14 @@ jobs:
           # var and is applied per-PR (workspace pr-<N>) by preview-env.yml, so it
           # must NOT be planned in the default workspace here. preview-shared IS
           # planned normally (grep -vx matches the exact dir only).
+          # infrastructure/modules/* are shared child modules, not root modules:
+          # they have no backend or provider and are planned via their callers.
           dirs=$(echo "${{ steps.changed-files.outputs.all_changed_files }}" | \
             tr ' ' '\n' | \
             xargs -I {} dirname {} | \
             sort -u | \
             grep -vx 'infrastructure/preview' | \
+            grep -v '^infrastructure/modules/' | \
             jq -R -s -c 'split("\n") | map(select(length > 0))')
 
           echo "Unique directories with changes: $dirs"

--- a/infrastructure/aws/README.md
+++ b/infrastructure/aws/README.md
@@ -17,7 +17,9 @@
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_tags"></a> [tags](#module\_tags) | ../modules/tags | n/a |
 
 ## Resources
 

--- a/infrastructure/aws/cognito.tf
+++ b/infrastructure/aws/cognito.tf
@@ -90,9 +90,9 @@ resource "aws_cognito_user_pool" "branch_user_pool" {
   # Prevent accidental deletion
   deletion_protection = "ACTIVE"
 
+  # Project comes from the provider's default_tags (infrastructure/modules/tags).
   tags = {
     Environment = "development"
-    Project     = "branch"
     ManagedBy   = "terraform"
   }
 }

--- a/infrastructure/aws/main.tf
+++ b/infrastructure/aws/main.tf
@@ -1,4 +1,11 @@
 resource "aws_db_instance" "branch_rds" {
+  # Was unset, so the provider generated a `terraform-<hex>` instance name. A
+  # rename is an in-place ModifyDBInstance, but it changes the endpoint host, so
+  # apply_immediately keeps the endpoint Terraform writes into the lambda env in
+  # sync with reality instead of leaving it pending until the maintenance window.
+  identifier        = "branch-rds"
+  apply_immediately = true
+
   allocated_storage = 10
   db_name           = "branch_rds"
   engine            = "postgres"

--- a/infrastructure/aws/providers.tf
+++ b/infrastructure/aws/providers.tf
@@ -10,8 +10,16 @@ terraform {
   }
 }
 
+module "tags" {
+  source = "../modules/tags"
+}
+
 provider "aws" {
   region = "us-east-2"
+
+  default_tags {
+    tags = module.tags.tags
+  }
 }
 
 provider "infisical" {

--- a/infrastructure/modules/tags/main.tf
+++ b/infrastructure/modules/tags/main.tf
@@ -1,0 +1,7 @@
+# Single source of truth for the tags on every AWS resource. Consumed through
+# `default_tags` in each root module's provider, so no resource repeats them.
+output "tags" {
+  value = {
+    Project = "branch"
+  }
+}

--- a/infrastructure/preview-shared/README.md
+++ b/infrastructure/preview-shared/README.md
@@ -15,7 +15,9 @@
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_tags"></a> [tags](#module\_tags) | ../modules/tags | n/a |
 
 ## Resources
 

--- a/infrastructure/preview-shared/providers.tf
+++ b/infrastructure/preview-shared/providers.tf
@@ -7,6 +7,14 @@ terraform {
   }
 }
 
+module "tags" {
+  source = "../modules/tags"
+}
+
 provider "aws" {
   region = "us-east-2"
+
+  default_tags {
+    tags = module.tags.tags
+  }
 }

--- a/infrastructure/preview/providers.tf
+++ b/infrastructure/preview/providers.tf
@@ -10,6 +10,14 @@ terraform {
   }
 }
 
+module "tags" {
+  source = "../modules/tags"
+}
+
 provider "aws" {
   region = "us-east-2"
+
+  default_tags {
+    tags = module.tags.tags
+  }
 }

--- a/infrastructure/test/README.md
+++ b/infrastructure/test/README.md
@@ -13,7 +13,9 @@ No providers.
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_tags"></a> [tags](#module\_tags) | ../modules/tags | n/a |
 
 ## Resources
 

--- a/infrastructure/test/providers.tf
+++ b/infrastructure/test/providers.tf
@@ -8,6 +8,14 @@ terraform {
   }
 }
 
+module "tags" {
+  source = "../modules/tags"
+}
+
 provider "aws" {
   region = "us-east-2"
+
+  default_tags {
+    tags = module.tags.tags
+  }
 }


### PR DESCRIPTION
## What

Two things:

1. **Every AWS resource gets `Project = branch`** — via `default_tags` on each root module's `aws` provider, sourced from one shared child module.
2. **The RDS instance gets a name.** It had no `identifier`, so the provider generated a `terraform-<hex>` name.

## How the tagging works

New child module, `infrastructure/modules/tags`, is the single source of truth:

```hcl
output "tags" {
  value = {
    Project = "branch"
  }
}
```

Each root module (`aws/`, `test/`, `preview/`, `preview-shared/`) adds four lines to its `providers.tf`:

```hcl
module "tags" {
  source = "../modules/tags"
}

provider "aws" {
  region = "us-east-2"

  default_tags {
    tags = module.tags.tags
  }
}
```

Adding or changing a tag later is a one-line edit in `modules/tags/main.tf` — nothing else changes. No resource declares `Project` itself; the now-redundant `Project = "branch"` on the Cognito user pool is removed (`Environment`/`ManagedBy` stay, they're pool-specific).

`github/` is untouched: it has no AWS provider, and GitHub resources have no tag concept.

Verified locally: `terraform validate` passes in all four root modules, and a scratch `plan` confirms a provider `default_tags` block can read a child-module output (this is the part that could plausibly have been rejected as "provider config can't depend on a module").

## RDS rename — read before merging

`identifier = "branch-rds"` is **not** a replacement: `identifier` isn't `ForceNew` in the AWS provider, so this is an in-place `ModifyDBInstance` rename. `prevent_destroy` on the instance is a backstop — if a plan ever *did* show replacement, it would fail rather than drop the database.

But a rename **changes the endpoint hostname** (`<identifier>.<hex>.us-east-2.rds.amazonaws.com`). Consequences:

- **Short outage.** `apply_immediately = true` is set so the rename happens during the apply instead of queuing to the maintenance window. Without it, Terraform records the new endpoint while AWS still serves the old one, and the six lambdas would get a `DB_HOST` that doesn't resolve until the window. The trade-off: `apply_immediately` stays on for *future* RDS changes too (e.g. engine-version bumps apply at once rather than queuing). Drop it after this rename lands if you'd rather changes queue.
- **Prod lambdas self-heal.** `aws/lambda.tf` reads `aws_db_instance.branch_rds.address`, so the same apply rewrites `DB_HOST` on all six functions.
- **Existing preview stacks will not self-heal.** Preview lambda env is only written when the label is added — a push never re-runs Terraform. Any preview stack alive across this merge keeps the old `DB_HOST` and loses the DB until it's re-labelled. Worth merging when no previews are open, or re-labelling them after.
- `lambda-deploy.yml` resolves the instance by matching `DB_HOST` against `Endpoint.Address`, so it follows the rename with no change.

I couldn't confirm the current identifier from here — my credentials see no RDS instances in `us-east-2` (different account from the CI `489881683177`), so the pre-rename name is inferred from the config, not observed. The plan comment on this PR will show the real before/after.

## CI

`terraform-plan.yml` and `terraform-apply.yml` now exclude `infrastructure/modules/*` from their changed-dir matrices — shared child modules have no backend or provider, so planning them as roots is meaningless (and `tfenv install` would fail with no `.terraform-version`). Side effect: a change touching *only* `modules/tags` triggers no apply. Use the manual `terraform-apply` dispatch with the caller dirs in that case.

Draft: the plan comment should be reviewed before this is marked ready — particularly the RDS diff and the tag-only in-place updates across existing resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
