### PR TITLE
fix(preview): reconcile preview lambda config on every push

### DIFF
--- a/.github/workflows/preview-env.yml
+++ b/.github/workflows/preview-env.yml
@@ -32,7 +32,6 @@ on:
 # DynamoDB state lock (which serializes any overlapping terraform) keep cleanup
 # reliable regardless of event ordering.
 env:
-  LABEL: test-environment
   AWS_REGION: us-east-2
   ROLE_ARN: arn:aws:iam::489881683177:role/branch-ci-preview
   TF_VERSION: 1.13.0
@@ -126,9 +125,14 @@ jobs:
       # Prod config is the single source of truth, DB_HOST included. Never re-derive
       # it from `DBInstances[0]` -- this account hosts other C4C databases and that
       # picked an unreachable one. Reserved / credential keys are dropped; the module
-      # adds NODE_ENV. Only needed when creating the stack.
+      # adds NODE_ENV.
+      #
+      # Runs on every event, not just label-add. Gating this on create meant a
+      # stack kept whatever env it was born with: when the RDS instance was given
+      # an explicit identifier its endpoint changed, and every existing preview
+      # kept the old `terraform-*` hostname, so all six lambdas 500'd on any
+      # request that touched the database while prod was fine.
       - name: Resolve preview lambda env
-        if: steps.mode.outputs.create == 'true'
         run: |
           set -euo pipefail
           AUTH_ENV=$(aws lambda get-function-configuration --function-name branch-auth --query 'Environment.Variables' --output json)
@@ -149,8 +153,9 @@ jobs:
           # Stash for the terraform step (multiline-safe).
           printf 'LAMBDA_ENV<<EOF\n%s\nEOF\n' "$ENV_JSON" >> "$GITHUB_ENV"
 
-      - name: Terraform apply (create/ensure preview stack)
-        if: steps.mode.outputs.create == 'true'
+      # Also every run: an apply is how the resolved env above actually reaches
+      # the functions. Cheap when nothing changed -- the plan is empty.
+      - name: Terraform apply (create/reconcile preview stack)
         working-directory: infrastructure/preview
         run: |
           cat > preview.auto.tfvars.json <<EOF
@@ -165,25 +170,11 @@ jobs:
         working-directory: infrastructure/preview
         run: |
           set -euo pipefail
-          if [ "${{ steps.mode.outputs.create }}" = "true" ]; then
-            API_URL=$(terraform output -raw api_gateway_url)
-          else
-            API_ID=$(aws apigateway get-rest-apis \
-              --query "items[?name=='branch-api-pr${PR}'].id | [0]" --output text)
-            if [ -z "$API_ID" ] || [ "$API_ID" = "None" ]; then
-              echo "::error::No preview API for PR #${PR}. Re-add the ${LABEL} label to (re)create it."
-              exit 1
-            fi
-            # The API existing is not enough. A stack whose apply died partway has
-            # the resources but no stage, and every call to it 403s without CORS
-            # headers, so the browser blames CORS. Fail here rather than posting a
-            # green "updated in place" on an environment that cannot serve a request.
-            if ! aws apigateway get-stage --rest-api-id "$API_ID" --stage-name prod >/dev/null 2>&1; then
-              echo "::error::Preview API ${API_ID} for PR #${PR} has no 'prod' stage — the stack is incomplete. Remove and re-add the ${LABEL} label to rebuild it."
-              exit 1
-            fi
-            API_URL="https://${API_ID}.execute-api.${AWS_REGION}.amazonaws.com/prod"
-          fi
+          # Straight from the apply above, in both modes. The old else-branch
+          # looked the API up by name and told the reader to re-add the label if
+          # it was missing or half-built; the apply now repairs that itself, or
+          # fails loudly and stops the job before this step.
+          API_URL=$(terraform output -raw api_gateway_url)
           echo "api_url=$API_URL" >> "$GITHUB_OUTPUT"
 
       # On create → all lambdas + frontend. On update → only what changed in the PR.


### PR DESCRIPTION
A preview stack kept whatever environment it was born with. Both the step that resolves the env from prod and the `terraform apply` that delivers it were gated on `create == 'true'`, so a labelled PR only ever redeployed lambda *code* on subsequent pushes -- the config was never revisited.

That went unnoticed until the RDS instance was given an explicit identifier. Its endpoint changed from `terraform-20251009192006341800000001...` to `branch-rds...`, prod picked the new value up on its next apply, and every preview stack created before that kept the old hostname. The old name no longer resolves, so all six preview lambdas threw

    getaddrinfo ENOTFOUND terraform-20251009192006341800000001...

on any request that reached the database. Public routes still worked, which made it look like an auth bug: POST /auth/login and /auth/respond-challenge answered normally while GET /auth/me -- the first route to resolve a caller -- returned `{"message":"Internal Server Error"}` from dispatch's catch-all.

Both steps now run on every event. Terraform is declarative, so an apply where the resolved config already matches is an empty plan.

With the apply no longer conditional, the API URL comes from `terraform output` in both modes. That retires the fallback that looked the API up by name and told the reader to re-add the label when it was missing or had no stage -- the apply either repairs the stack or fails and stops the job. `LABEL` went with those two messages, its only consumers.

### ℹ️ Issue

Closes <issue>

### 📝 Description

Write a short summary of what you added. Why is it important? Any member of C4C should be able to read this and understand your contribution -- not just your team members.

Briefly list the changes made to the code:
1. Added support for this.
2. And removed redunant use of that.
3. Also this was included for reasons.

### ✔️ Verification

What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves.

Provide screenshots of any new components, styling changes, or pages. 

### 🏕️ (Optional) Future Work / Notes

Did you notice anything ugly during the course of this ticket? Any bugs, design challenges, or unexpected behavior? Write it down so we can clean it up in a future ticket!
