### PR TITLE
perf(infra): answer CORS preflights in API Gateway, not in a lambda

### DIFF
--- a/infrastructure/aws/README.md
+++ b/infrastructure/aws/README.md
@@ -28,10 +28,14 @@
 |------|------|
 | [aws_api_gateway_deployment.branch_deployment](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/api_gateway_deployment) | resource |
 | [aws_api_gateway_gateway_response.cors](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/api_gateway_gateway_response) | resource |
+| [aws_api_gateway_integration.cors](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/api_gateway_integration) | resource |
 | [aws_api_gateway_integration.lambda_integrations](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/api_gateway_integration) | resource |
 | [aws_api_gateway_integration.lambda_proxy_integrations](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/api_gateway_integration) | resource |
+| [aws_api_gateway_integration_response.cors](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/api_gateway_integration_response) | resource |
+| [aws_api_gateway_method.cors_proxy_options](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/api_gateway_method) | resource |
 | [aws_api_gateway_method.lambda_methods](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/api_gateway_method) | resource |
 | [aws_api_gateway_method.lambda_proxy_any](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/api_gateway_method) | resource |
+| [aws_api_gateway_method_response.cors](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/api_gateway_method_response) | resource |
 | [aws_api_gateway_resource.lambda_proxy](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/api_gateway_resource) | resource |
 | [aws_api_gateway_resource.lambda_resources](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/api_gateway_resource) | resource |
 | [aws_api_gateway_rest_api.branch_api](https://registry.terraform.io/providers/hashicorp/aws/6.14.1/docs/resources/api_gateway_rest_api) | resource |

--- a/infrastructure/aws/api_gateway.tf
+++ b/infrastructure/aws/api_gateway.tf
@@ -3,6 +3,11 @@ resource "aws_api_gateway_rest_api" "branch_api" {
   name        = "branch-api"
   description = "API Gateway for Branch Lambda functions"
 
+  # Gzip any response over 1 KB. List endpoints are JSON and compress 70-80%.
+  # Below ~1 KB the gzip header outweighs the saving, hence the floor rather
+  # than 0. Costs nothing: compression happens in API Gateway, not the lambda.
+  minimum_compression_size = 1024
+
   endpoint_configuration {
     types = ["REGIONAL"]
   }
@@ -35,9 +40,10 @@ resource "aws_api_gateway_gateway_response" "cors" {
 # OPTIONS is appended to every resource so browser CORS preflights are answered.
 # The frontend sends Content-Type: application/json on every call (see
 # apps/frontend/src/lib/api.ts), which makes even GETs non-simple and triggers a
-# preflight; the frontend (CloudFront) and this API are cross-origin. Preflight
-# is routed to the proxy lambda, which short-circuits OPTIONS with 200 +
-# Access-Control-Allow-Origin: * (see each handler's json() helper).
+# preflight; the frontend (CloudFront) and this API are cross-origin.
+#
+# The OPTIONS method stays in this map so its address does not churn, but its
+# integration is MOCK, not AWS_PROXY -- see aws_api_gateway_integration.cors.
 locals {
   base_methods = {
     auth         = ["GET", "POST"]
@@ -77,10 +83,11 @@ resource "aws_api_gateway_method" "lambda_methods" {
   authorization = "NONE"
 }
 
-# Create Lambda integrations
+# Create Lambda integrations. base_methods, not lambda_methods: OPTIONS is
+# answered by MOCK below and must not reach a lambda.
 resource "aws_api_gateway_integration" "lambda_integrations" {
   for_each = merge([
-    for lambda, methods in local.lambda_methods : {
+    for lambda, methods in local.base_methods : {
       for method in methods :
       "${lambda}-${method}" => {
         lambda = lambda
@@ -133,6 +140,141 @@ resource "aws_api_gateway_integration" "lambda_proxy_integrations" {
   uri                     = aws_lambda_function.functions[each.key].invoke_arn
 }
 
+# ---------------------------------------------------------------------------
+# CORS preflight, answered by API Gateway instead of by a lambda.
+#
+# Every browser call here is preflighted: the frontend sends Authorization and
+# Content-Type: application/json, which makes even a GET non-simple, and
+# CloudFront and API Gateway are different origins.
+#
+# Those preflights used to be AWS_PROXY, so each one woke a lambda -- doubling
+# invocations and paying a full cold start (a multi-MB bundle parse) to answer a
+# request that carries no body. dispatch() short-circuits OPTIONS before it
+# authenticates or touches the database, so nothing of value happened there.
+#
+# Access-Control-Max-Age is the other half, and the more valuable one: with no
+# Max-Age, Chrome caches a preflight for ~5 seconds, so in practice every
+# request paid for its own. 7200 is Chrome's ceiling -- it silently clamps
+# anything larger, so asking for 86400 buys nothing.
+locals {
+  # The bare /service resource and its /{proxy+} child each need their own
+  # OPTIONS: {proxy+} does not match the parent path.
+  #
+  # Holds the service name and which of the two resources it means, NOT the
+  # resource id. for_each keys must be known at plan time, and a map built out
+  # of resource attributes is a good way to get "cannot be determined until
+  # apply" on a fresh state. The id lookup happens inside each block instead.
+  cors_targets = merge(
+    { for svc in local.lambda_functions : svc => { svc = svc, proxy = false } },
+    { for svc in local.lambda_functions : "${svc}-proxy" => { svc = svc, proxy = true } },
+  )
+
+  # Values are single-quoted because API Gateway wants a static mapping literal.
+  # Kept identical to what the lambda json() helper returned, so this changes
+  # who answers a preflight, not what a preflight says.
+  cors_headers = {
+    "Access-Control-Allow-Origin"  = "'*'"
+    "Access-Control-Allow-Headers" = "'Content-Type,Authorization'"
+    "Access-Control-Allow-Methods" = "'GET,POST,PUT,PATCH,DELETE,OPTIONS'"
+    "Access-Control-Max-Age"       = "'7200'"
+  }
+}
+
+# Only the proxy resources need a new method: the bare ones already have OPTIONS
+# from local.lambda_methods. Declaring it twice would be two Terraform addresses
+# fighting over one API Gateway method. An explicit OPTIONS also takes
+# precedence over the ANY on the same resource.
+resource "aws_api_gateway_method" "cors_proxy_options" {
+  for_each = local.lambda_functions
+
+  rest_api_id   = aws_api_gateway_rest_api.branch_api.id
+  resource_id   = aws_api_gateway_resource.lambda_proxy[each.key].id
+  http_method   = "OPTIONS"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "cors" {
+  for_each = local.cors_targets
+
+  rest_api_id = aws_api_gateway_rest_api.branch_api.id
+  resource_id = each.value.proxy ? aws_api_gateway_resource.lambda_proxy[each.value.svc].id : aws_api_gateway_resource.lambda_resources[each.value.svc].id
+  http_method = "OPTIONS"
+
+  type = "MOCK"
+  request_templates = {
+    "application/json" = "{\"statusCode\":200}"
+  }
+
+  depends_on = [
+    aws_api_gateway_method.lambda_methods,
+    aws_api_gateway_method.cors_proxy_options,
+  ]
+}
+
+resource "aws_api_gateway_method_response" "cors" {
+  for_each = local.cors_targets
+
+  rest_api_id = aws_api_gateway_rest_api.branch_api.id
+  resource_id = each.value.proxy ? aws_api_gateway_resource.lambda_proxy[each.value.svc].id : aws_api_gateway_resource.lambda_resources[each.value.svc].id
+  http_method = "OPTIONS"
+  status_code = "200"
+
+  response_parameters = { for h in keys(local.cors_headers) : "method.response.header.${h}" => true }
+
+  depends_on = [
+    aws_api_gateway_method.lambda_methods,
+    aws_api_gateway_method.cors_proxy_options,
+  ]
+}
+
+resource "aws_api_gateway_integration_response" "cors" {
+  for_each = local.cors_targets
+
+  rest_api_id = aws_api_gateway_rest_api.branch_api.id
+  resource_id = each.value.proxy ? aws_api_gateway_resource.lambda_proxy[each.value.svc].id : aws_api_gateway_resource.lambda_resources[each.value.svc].id
+  http_method = "OPTIONS"
+  status_code = aws_api_gateway_method_response.cors[each.key].status_code
+
+  response_parameters = { for h, v in local.cors_headers : "method.response.header.${h}" => v }
+
+  depends_on = [aws_api_gateway_integration.cors]
+}
+
+# REQUIRED, not cosmetic. Without these, Terraform sees an integration to create
+# at the new address and one to destroy at the old, both pointing at the same
+# (resource, OPTIONS) pair in API Gateway. It creates the MOCK, then the destroy
+# deletes it -- leaving OPTIONS with no integration at all and 500ing every
+# preflight in the app. `moved` makes it one in-place replacement instead.
+moved {
+  from = aws_api_gateway_integration.lambda_integrations["auth-OPTIONS"]
+  to   = aws_api_gateway_integration.cors["auth"]
+}
+
+moved {
+  from = aws_api_gateway_integration.lambda_integrations["donors-OPTIONS"]
+  to   = aws_api_gateway_integration.cors["donors"]
+}
+
+moved {
+  from = aws_api_gateway_integration.lambda_integrations["expenditures-OPTIONS"]
+  to   = aws_api_gateway_integration.cors["expenditures"]
+}
+
+moved {
+  from = aws_api_gateway_integration.lambda_integrations["projects-OPTIONS"]
+  to   = aws_api_gateway_integration.cors["projects"]
+}
+
+moved {
+  from = aws_api_gateway_integration.lambda_integrations["reports-OPTIONS"]
+  to   = aws_api_gateway_integration.cors["reports"]
+}
+
+moved {
+  from = aws_api_gateway_integration.lambda_integrations["users-OPTIONS"]
+  to   = aws_api_gateway_integration.cors["users"]
+}
+
 # Allow API Gateway to invoke Lambda functions
 resource "aws_lambda_permission" "api_gateway_permissions" {
   for_each = local.lambda_functions
@@ -151,17 +293,21 @@ resource "aws_api_gateway_deployment" "branch_deployment" {
   depends_on = [
     aws_api_gateway_integration.lambda_integrations,
     aws_api_gateway_integration.lambda_proxy_integrations,
+    aws_api_gateway_integration.cors,
+    aws_api_gateway_integration_response.cors,
   ]
 
   rest_api_id = aws_api_gateway_rest_api.branch_api.id
 
   # Force a new deployment when routing changes (e.g. the OPTIONS methods added
   # for CORS, or the {proxy+} sub-path routes) — otherwise the stage keeps
-  # serving the old method set.
+  # serving the old method set. cors_headers is in here too: changing Max-Age is
+  # a change to what the stage serves, and would otherwise not redeploy.
   triggers = {
     redeploy = sha1(jsonencode({
       methods = local.lambda_methods
       proxy   = tolist(local.lambda_functions)
+      cors    = local.cors_headers
     }))
   }
 


### PR DESCRIPTION
## What

Two API Gateway changes, both of which *reduce* spend.

### 1. `OPTIONS` is now a MOCK integration

Every browser call to this API is preflighted — the frontend sends `Authorization` and `Content-Type: application/json`, which makes even a `GET` non-simple, and CloudFront and API Gateway are different origins.

Those preflights were `AWS_PROXY`, so **each one woke a lambda**. That doubled invocation count and paid a full cold start — a multi-MB bundle parse — to answer a request with no body. `dispatch()` short-circuits `OPTIONS` before it authenticates or opens a connection, so nothing of value was happening in there.

And nothing set `Access-Control-Max-Age`, which is the larger half of the problem: with no `Max-Age`, Chrome caches a preflight for **~5 seconds**, so in practice every request paid for its own. `7200` is Chrome's ceiling — it silently clamps anything larger, so asking for 86400 buys nothing.

The MOCK returns the same four headers the lambda `json()` helper returned. **This changes who answers a preflight, not what a preflight says.**

### 2. `minimum_compression_size = 1024`

API Gateway now gzips responses over 1 KB. List endpoints are JSON and compress 70-80%. The floor is 1024 rather than 0 because below that the gzip header outweighs the saving. Compression happens in API Gateway, not in the lambda.

## Why the `moved` blocks are load-bearing

Read these before approving — they are **not** cosmetic.

The bare `/service` resources already have an `OPTIONS` method from `local.lambda_methods`. Only the *integration* changes address, from `lambda_integrations["auth-OPTIONS"]` to `cors["auth"]`. Without a `moved` block, Terraform sees an integration to create at the new address and one to destroy at the old, **both pointing at the same `(resource, OPTIONS)` pair in API Gateway**. It creates the MOCK, then the destroy deletes it — leaving `OPTIONS` with no integration and 500ing every preflight in the app.

`moved` turns that into one in-place replacement instead.

Structural notes:
- The `OPTIONS` method stays in `local.lambda_methods` deliberately, so its address does not churn. `lambda_integrations` now iterates `base_methods` instead.
- `/{proxy+}` gains an **explicit** `OPTIONS` method. An explicit method takes precedence over the `ANY` already on that resource, and `{proxy+}` does not match its parent path, so both resources need their own.
- `local.cors_targets` holds `{svc, proxy}` rather than resource ids: `for_each` keys must be known at plan time, and a map built from resource attributes is a good way to get "cannot be determined until apply".
- The deployment `triggers` now include `cors_headers`, since changing `Max-Age` changes what the stage serves and would otherwise not redeploy.

## Verification — please read, this is partial

- `terraform fmt -check` clean, `terraform validate` **Success**.
- **No plan was run.** `data "infisical_secrets"` needs a token I do not have, and the AWS credentials available locally resolve to an account with no `branch-api` and no lambdas, so I could not inspect live state either. CI's `terraform-plan` is the real gate here.

**Before merging, confirm in the plan that:**
1. The six `moved` blocks resolve — no `aws_api_gateway_integration` is being created *and* destroyed for the same service.
2. `aws_api_gateway_method.lambda_methods["*-OPTIONS"]` is **unchanged** (not replaced).
3. Twelve each of `aws_api_gateway_integration.cors`, `method_response.cors`, `integration_response.cors` are created, plus six `cors_proxy_options` methods.

Expect a brief window during apply where preflights fail: changing an integration's `type` forces replacement, so `OPTIONS` is momentarily integration-less. Applying outside peak is sensible.

After apply, the check that matters:

```
curl -i -X OPTIONS https://<api>/prod/projects \
  -H 'Origin: https://<frontend>' \
  -H 'Access-Control-Request-Method: GET' \
  -H 'Access-Control-Request-Headers: authorization,content-type'
```

Expect `200`, an `Access-Control-Max-Age: 7200` header, and **no log line in any lambda's CloudWatch group**.

## Context

From the load-time audit. Related: #358 (bundle size), #359 (indexes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
