### PR TITLE
perf(infra): enable RDS Performance Insights on the free tier

### DIFF
--- a/infrastructure/aws/main.tf
+++ b/infrastructure/aws/main.tf
@@ -26,6 +26,15 @@ resource "aws_db_instance" "branch_rds" {
   # so pinning one guesses against the other. Pin both or neither.
   backup_retention_period = 7
 
+  # Per-statement timing, so a slow endpoint can be diagnosed from data instead
+  # of inferred from source. 7 days is the free retention tier and is free on
+  # every class -- db.t3.micro included, despite the older docs implying t3 is
+  # excluded (describe-orderable-db-instance-options reports
+  # SupportsPerformanceInsights = true for postgres here). Longer retention is
+  # the paid tier, so 7 is deliberate, not a default.
+  performance_insights_enabled          = true
+  performance_insights_retention_period = 7
+
   # The lambdas in lambda.tf have no vpc_config, so they run outside any VPC and
   # had no route to this instance while it was private -- every DB-backed request
   # hung until the 30s lambda timeout. Putting them in the VPC instead is the


### PR DESCRIPTION
## What

Enables RDS Performance Insights on `branch_rds`, at the free 7-day retention tier.

```hcl
performance_insights_enabled          = true
performance_insights_retention_period = 7
```

## Why

Every performance question about this database has so far been answered by reading source and reasoning about query plans — including the load-time audit that produced #358, #359 and #360. Performance Insights answers them from data: per-statement timing, top SQL by load, and wait events.

Concretely, it is what would let us confirm or refute the two index caveats in the follow-up indexes migration, rather than guessing whether `status = 'approved'` is selective enough to be worth an index.

## Cost

**$0.** The 7-day retention tier is free on every instance class.

Retention is pinned at `7` rather than left to the provider default deliberately — longer retention is the paid tier, and an unpinned value is an easy way to start paying by accident.

## The t3.micro question

This was not enabled earlier because older AWS documentation implies the burstable `t3` family is excluded from Performance Insights. That is out of date for this class. Verified rather than assumed:

```
$ aws rds describe-orderable-db-instance-options \
    --engine postgres --db-instance-class db.t3.micro --region us-east-2 \
    --query 'OrderableDBInstanceOptions[0].[DBInstanceClass,SupportsPerformanceInsights]'
[ "db.t3.micro", true ]
```

## Apply impact

In-place `ModifyDBInstance`. No downtime, no reboot, no replacement. `apply_immediately = true` is already set on this resource, so it takes effect on apply rather than waiting for the maintenance window.

## Verification

`terraform fmt -check` clean, `terraform validate` **Success**.

**No plan was run** — `data "infisical_secrets"` needs a token I do not have. CI's `terraform-plan` is the gate. The expected diff is two added attributes on `aws_db_instance.branch_rds` and nothing else; in particular confirm it is **not** proposing a replacement, since `prevent_destroy` is set and `skip_final_snapshot = true` means a replacement would destroy the database with no backup.

## Not included

The gp2 → gp3 storage change from the audit is deliberately left out. It is the one recommendation that costs anything (~+$1.15/mo for 3000 baseline IOPS instead of 100) and is not worth it at the current user count. Worth revisiting if Performance Insights shows IO waits.

## Context

From the load-time audit. Related: #358 (bundle size), #359 (indexes), #360 (CORS preflights).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
