### PR TITLE
fix(infra): let the preview role read the Sentry layer

### DIFF
--- a/infrastructure/aws/oidc.tf
+++ b/infrastructure/aws/oidc.tf
@@ -150,6 +150,12 @@ resource "aws_iam_role_policy" "ci_preview" {
         Action   = ["lambda:GetFunction", "lambda:GetFunctionConfiguration", "lambda:ListFunctions"]
         Resource = "*"
       },
+      {
+        Sid      = "ReadSentryLayer"
+        Effect   = "Allow"
+        Action   = ["lambda:GetLayerVersion"]
+        Resource = module.sentry.layer_arn
+      },
       # API Gateway: create/destroy per-PR REST APIs. ARNs are random ids, so
       # this cannot be name-scoped — bounded to the account/region instead.
       {


### PR DESCRIPTION
## Problem

Preview envs have been failing since Sentry landed (#357):

```
Error: creating Lambda Function (branch-pr358-users): api error AccessDeniedException:
User: arn:aws:sts::489881683177:assumed-role/branch-ci-preview/GitHubActions is not
authorized to perform: lambda:GetLayerVersion on resource:
arn:aws:lambda:us-east-2:943013980633:layer:SentryNodeServerlessSDKv10:85
```

`preview/lambda.tf` now sets `layers = [module.sentry.layer_arn]`. Attaching a layer requires `lambda:GetLayerVersion` **on the layer**, and the layer lives in Sentry's account (`943013980633`), so the existing `PreviewLambdas` statement — `lambda:*` scoped to `function:branch-pr*` in our account — does not cover it. `terraform apply` 403s on the first `CreateFunction`.

Prod is unaffected: `branch-ci-apply` has `AdministratorAccess`.

## Fix

One statement on the `branch-ci-preview` inline policy:

```hcl
{
  Sid      = "ReadSentryLayer"
  Effect   = "Allow"
  Action   = ["lambda:GetLayerVersion"]
  Resource = module.sentry.layer_arn
}
```

Resource is `module.sentry.layer_arn` rather than a literal, so bumping the SDK version in `modules/sentry` moves the IAM grant with it instead of silently re-breaking previews.

## Rollout

This is in the `aws/` root, so it takes effect only after `terraform-apply` runs on merge to main. Preview envs opened before that still fail; re-run `preview-env.yml` (or re-add the label) once the apply is green.

## Verification

- `terraform fmt -check` clean
- `terraform validate` on `infrastructure/aws` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)