### PR TITLE
perf(lambdas): size the pg pool for one-request-per-container

### DIFF
--- a/apps/backend/lambdas/auth/db.ts
+++ b/apps/backend/lambdas/auth/db.ts
@@ -20,6 +20,18 @@ const db = new Kysely<DB>({
       // Without this a blackholed SYN hangs until the 30s lambda timeout instead
       // of erroring, which is how the unreachable-database bug presented.
       connectionTimeoutMillis: 5000,
+
+      // A lambda container serves one request at a time, so pg's default of 10
+      // just multiplies idle sockets against db.t3.micro's ~112 max_connections.
+      max: 1,
+
+      // Lambda freezes the container between invocations, so the idle timer fires
+      // late and the pool can hand back a socket the server already dropped.
+      idleTimeoutMillis: 0,
+      keepAlive: true,
+
+      // Bound a runaway query well under the 30s lambda timeout.
+      statement_timeout: 10000,
     }),
   }),
 })

--- a/apps/backend/lambdas/donors/db.ts
+++ b/apps/backend/lambdas/donors/db.ts
@@ -20,6 +20,18 @@ const db = new Kysely<DB>({
       // Without this a blackholed SYN hangs until the 30s lambda timeout instead
       // of erroring, which is how the unreachable-database bug presented.
       connectionTimeoutMillis: 5000,
+
+      // A lambda container serves one request at a time, so pg's default of 10
+      // just multiplies idle sockets against db.t3.micro's ~112 max_connections.
+      max: 1,
+
+      // Lambda freezes the container between invocations, so the idle timer fires
+      // late and the pool can hand back a socket the server already dropped.
+      idleTimeoutMillis: 0,
+      keepAlive: true,
+
+      // Bound a runaway query well under the 30s lambda timeout.
+      statement_timeout: 10000,
     }),
   }),
 })

--- a/apps/backend/lambdas/expenditures/db.ts
+++ b/apps/backend/lambdas/expenditures/db.ts
@@ -20,6 +20,18 @@ const db = new Kysely<DB>({
       // Without this a blackholed SYN hangs until the 30s lambda timeout instead
       // of erroring, which is how the unreachable-database bug presented.
       connectionTimeoutMillis: 5000,
+
+      // A lambda container serves one request at a time, so pg's default of 10
+      // just multiplies idle sockets against db.t3.micro's ~112 max_connections.
+      max: 1,
+
+      // Lambda freezes the container between invocations, so the idle timer fires
+      // late and the pool can hand back a socket the server already dropped.
+      idleTimeoutMillis: 0,
+      keepAlive: true,
+
+      // Bound a runaway query well under the 30s lambda timeout.
+      statement_timeout: 10000,
     }),
   }),
 })

--- a/apps/backend/lambdas/projects/db.ts
+++ b/apps/backend/lambdas/projects/db.ts
@@ -19,6 +19,18 @@ const db = new Kysely<DB>({
       // Without this a blackholed SYN hangs until the 30s lambda timeout instead
       // of erroring, which is how the unreachable-database bug presented.
       connectionTimeoutMillis: 5000,
+
+      // A lambda container serves one request at a time, so pg's default of 10
+      // just multiplies idle sockets against db.t3.micro's ~112 max_connections.
+      max: 1,
+
+      // Lambda freezes the container between invocations, so the idle timer fires
+      // late and the pool can hand back a socket the server already dropped.
+      idleTimeoutMillis: 0,
+      keepAlive: true,
+
+      // Bound a runaway query well under the 30s lambda timeout.
+      statement_timeout: 10000,
     }),
   }),
 })

--- a/apps/backend/lambdas/reports/db.ts
+++ b/apps/backend/lambdas/reports/db.ts
@@ -19,6 +19,18 @@ const db = new Kysely<DB>({
       // Without this a blackholed SYN hangs until the 30s lambda timeout instead
       // of erroring, which is how the unreachable-database bug presented.
       connectionTimeoutMillis: 5000,
+
+      // A lambda container serves one request at a time, so pg's default of 10
+      // just multiplies idle sockets against db.t3.micro's ~112 max_connections.
+      max: 1,
+
+      // Lambda freezes the container between invocations, so the idle timer fires
+      // late and the pool can hand back a socket the server already dropped.
+      idleTimeoutMillis: 0,
+      keepAlive: true,
+
+      // Bound a runaway query well under the 30s lambda timeout.
+      statement_timeout: 10000,
     }),
   }),
 })

--- a/apps/backend/lambdas/users/db.ts
+++ b/apps/backend/lambdas/users/db.ts
@@ -20,6 +20,18 @@ const db = new Kysely<DB>({
       // Without this a blackholed SYN hangs until the 30s lambda timeout instead
       // of erroring, which is how the unreachable-database bug presented.
       connectionTimeoutMillis: 5000,
+
+      // A lambda container serves one request at a time, so pg's default of 10
+      // just multiplies idle sockets against db.t3.micro's ~112 max_connections.
+      max: 1,
+
+      // Lambda freezes the container between invocations, so the idle timer fires
+      // late and the pool can hand back a socket the server already dropped.
+      idleTimeoutMillis: 0,
+      keepAlive: true,
+
+      // Bound a runaway query well under the 30s lambda timeout.
+      statement_timeout: 10000,
     }),
   }),
 })


### PR DESCRIPTION
Four `pg.Pool` settings, applied identically to all six lambdas' `db.ts` (`auth`, `donors`, `expenditures`, `projects`, `reports`, `users`). No other lines touched.

## `max: 1` — connection exhaustion

`max` was unset, so pg defaulted to **10** connections per pool. A Lambda container serves exactly one request at a time, so nine of those ten are dead weight — and the real ceiling is:

```
concurrent containers x 6 services x 10 connections
```

The instance is `db.t3.micro` (1 GiB RAM), where Postgres `max_connections` works out to roughly **112**. At 10 per pool that is exhausted by about 2 concurrent containers per service. Past that, new connections are refused, so requests fail outright rather than merely queueing. `max: 1` makes the per-container footprint match what a container can actually use and drops the ceiling by 10x.

## `idleTimeoutMillis: 0` + `keepAlive: true` — the Lambda freeze

pg's default 10s idle reaper assumes a process that keeps running. Lambda freezes the container between invocations, so the timer does not fire on schedule; on thaw the pool can hand out a socket that the server has already dropped, which surfaces as an intermittent connection error on the first query after an idle period. Disabling client-side reaping and letting the OS keep the socket healthy with TCP keepalives is the right pairing for a frozen-then-thawed process.

## `statement_timeout: 10000`

Nothing previously bounded a slow query below the 30s Lambda timeout, so a runaway query burned the full 30s and the client got a timeout rather than an error. 10s sits comfortably under the function timeout. (`pg` accepts `statement_timeout` as a Pool option and forwards it to the server.)

## Note on file drift

The six `db.ts` files were **not** byte-identical on `main` — they differ in leading/trailing blank lines and blank-line placement around the imports and `export default`. The `new Pool({ ... })` options block itself was identical in all six, so the same patch applies cleanly to each; the surrounding whitespace differences were left exactly as they were rather than normalized.

## Verification

`npx tsc --noEmit` — clean in all six lambdas (which also confirms `keepAlive` and `statement_timeout` are valid `PoolConfig` keys in the pinned `@types/pg`).

| suite | result |
| --- | --- |
| `auth` | 84/84 pass |
| `donors` | 59/60 pass |
| `expenditures` | 128/128 pass |
| `projects` | 115/115 pass |
| `reports` | 112/112 pass |
| `users` | 53/53 pass |
| `shared/rbac` | 28/28 pass |
| `shared/lambda-auth` | 20/20 pass |
| `shared/lambda-http` | 34/34 pass |

The single `donors` failure is `Donor API with data › health test`, a bare `fetch('http://localhost:3000/donors/health')` that needs the dev server running. It fails the same way on clean `main` and is unrelated to this change. The `auth` numbers above are from `npm test`, which boots the dev server — so that suite exercised the new pool settings against a live Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)