### PR TITLE
perf(frontend): trim the Chakra system to the recipes actually used

### DIFF
--- a/apps/frontend/src/app/providers.tsx
+++ b/apps/frontend/src/app/providers.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { ChakraProvider, defaultSystem } from '@chakra-ui/react';
+import { ChakraProvider } from '@chakra-ui/react';
+import { chakraSystem } from '@/lib/chakraSystem';
 import { AuthProvider } from '@/context/AuthContext';
 import AuthGate from './components/AuthGate';
 
@@ -10,7 +11,7 @@ import AuthGate from './components/AuthGate';
 // its own test file.
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <ChakraProvider value={defaultSystem}>
+    <ChakraProvider value={chakraSystem}>
       <AuthProvider>
         <AuthGate>{children}</AuthGate>
       </AuthProvider>

--- a/apps/frontend/src/lib/chakraSystem.ts
+++ b/apps/frontend/src/lib/chakraSystem.ts
@@ -1,0 +1,79 @@
+import { createSystem, defaultBaseConfig, defineConfig } from '@chakra-ui/react';
+import {
+  animationStyles,
+  breakpoints,
+  buttonRecipe,
+  checkboxSlotRecipe,
+  checkmarkRecipe,
+  cssVarsPrefix,
+  cssVarsRoot,
+  dialogSlotRecipe,
+  fieldSlotRecipe,
+  globalCss,
+  iconRecipe,
+  inputRecipe,
+  keyframes,
+  layerStyles,
+  nativeSelectSlotRecipe,
+  selectSlotRecipe,
+  semanticTokens,
+  spinnerRecipe,
+  tableSlotRecipe,
+  textareaRecipe,
+  textStyles,
+  tokens,
+} from '@chakra-ui/react/theme';
+
+/**
+ * Chakra's `defaultSystem` registers all ~19 recipes and ~54 slot recipes, and
+ * the whole table lands in the shared chunk on every route — including
+ * /dashboard and /projects, which render no Chakra at all. This rebuilds the
+ * same system from `defaultBaseConfig` with only the recipes we actually
+ * render, which lets the bundler drop the rest.
+ *
+ * Everything that is not a recipe (conditions, utilities, tokens, preflight,
+ * globalCss, cssVars naming) is kept byte-identical to `defaultSystem`, so the
+ * CSS reset still outranks Tailwind exactly as before.
+ *
+ * Adding a Chakra component means adding its recipe here, or it renders
+ * unstyled without throwing. `recipes.js` / `slot-recipes.js` in
+ * `@chakra-ui/react/dist/esm/theme` map component to recipe key.
+ */
+const themeConfig = defineConfig({
+  preflight: true,
+  cssVarsPrefix,
+  cssVarsRoot,
+  globalCss,
+  theme: {
+    breakpoints,
+    keyframes,
+    tokens,
+    semanticTokens,
+    // Kept whole: the recipes below reference textStyle/layerStyle/animationStyle
+    // by name, and they are ~6 KB unminified in total.
+    textStyles,
+    layerStyles,
+    animationStyles,
+    recipes: {
+      button: buttonRecipe,
+      input: inputRecipe,
+      textarea: textareaRecipe,
+      // icon: Field and the Select/NativeSelect indicators render Chakra icons.
+      icon: iconRecipe,
+      // checkmark: Checkbox.Control renders it.
+      checkmark: checkmarkRecipe,
+      // spinner: Button renders a Loader when `loading` is set.
+      spinner: spinnerRecipe,
+    },
+    slotRecipes: {
+      checkbox: checkboxSlotRecipe,
+      dialog: dialogSlotRecipe,
+      field: fieldSlotRecipe,
+      nativeSelect: nativeSelectSlotRecipe,
+      select: selectSlotRecipe,
+      table: tableSlotRecipe,
+    },
+  },
+});
+
+export const chakraSystem = createSystem(defaultBaseConfig, themeConfig);

--- a/apps/frontend/test/lib/chakraSystem.test.ts
+++ b/apps/frontend/test/lib/chakraSystem.test.ts
@@ -1,0 +1,109 @@
+import { defaultSystem } from '@chakra-ui/react';
+import { chakraSystem } from '@/lib/chakraSystem';
+
+/**
+ * `chakraSystem` exists only to keep Chakra's unused recipes out of the bundle.
+ * The failure mode it introduces is silent: drop a recipe a component still
+ * renders and that component loses its styles without throwing. These tests pin
+ * the trimmed system against `defaultSystem` so that regression is a red test
+ * rather than a visual surprise.
+ *
+ * Adding a Chakra component? Add its recipe key to the list below AND to
+ * src/lib/chakraSystem.ts. `dist/esm/theme/recipes.js` and `slot-recipes.js`
+ * in @chakra-ui/react map component to key.
+ */
+
+/** Every recipe key reachable from a component we import. */
+const RECIPES = [
+  'button', // Button, and CloseButton -> IconButton -> Button
+  'input', // Input
+  'textarea', // Textarea
+  'icon', // Field's create-icon, Select/NativeSelect indicators
+  'checkmark', // Checkbox.Control
+  'spinner', // Button's Loader, when `loading` is set
+];
+
+const SLOT_RECIPES = ['checkbox', 'dialog', 'field', 'nativeSelect', 'select', 'table'];
+
+describe('chakraSystem', () => {
+  it('registers every recipe our components resolve', () => {
+    for (const key of RECIPES) {
+      expect(chakraSystem.isRecipe(key)).toBe(true);
+    }
+    for (const key of SLOT_RECIPES) {
+      expect(chakraSystem.isSlotRecipe(key)).toBe(true);
+    }
+  });
+
+  it.each(RECIPES)('recipe %s is identical to defaultSystem', (key) => {
+    expect(chakraSystem.getRecipe(key)).toStrictEqual(defaultSystem.getRecipe(key));
+  });
+
+  it.each(SLOT_RECIPES)('slot recipe %s is identical to defaultSystem', (key) => {
+    expect(chakraSystem.getSlotRecipe(key)).toStrictEqual(defaultSystem.getSlotRecipe(key));
+  });
+
+  // The repo leans on Chakra's reset outranking Tailwind and uses `!`-prefixed
+  // utilities to win; a changed reset would move borders and spacing everywhere.
+  it('emits the same preflight, global CSS and design tokens', () => {
+    expect(chakraSystem.getPreflightCss()).toStrictEqual(defaultSystem.getPreflightCss());
+    expect(chakraSystem.getGlobalCss()).toStrictEqual(defaultSystem.getGlobalCss());
+    expect(chakraSystem.getTokenCss()).toStrictEqual(defaultSystem.getTokenCss());
+  });
+
+  it.each([
+    'colors.blue.500',
+    'colors.border',
+    'colors.bg',
+    'colors.fg',
+    'spacing.4',
+    'radii.l2',
+    'sizes.10',
+    'fontSizes.md',
+  ])('resolves token %s the same way', (token) => {
+    expect(chakraSystem.token(token)).toStrictEqual(defaultSystem.token(token));
+  });
+
+  it('resolves the variants our components actually ask for', () => {
+    const cases: Array<[string, Record<string, string>]> = [
+      ['button', { variant: 'solid', size: 'md' }],
+      ['button', { variant: 'ghost', size: 'sm' }],
+      ['input', { variant: 'outline', size: 'md' }],
+      ['textarea', { variant: 'outline', size: 'md' }],
+      ['icon', {}],
+      ['checkmark', { size: 'md' }],
+      ['spinner', { size: 'md' }],
+    ];
+    for (const [key, variant] of cases) {
+      const trimmed = chakraSystem.cva(chakraSystem.getRecipe(key))(variant);
+      const original = defaultSystem.cva(defaultSystem.getRecipe(key))(variant);
+      expect(chakraSystem.css(trimmed)).toStrictEqual(defaultSystem.css(original));
+    }
+
+    const slotCases: Array<[string, Record<string, string>]> = [
+      ['table', { variant: 'line', size: 'md' }],
+      ['dialog', { placement: 'center', size: 'md' }],
+      ['select', { variant: 'outline', size: 'md' }],
+      ['nativeSelect', { variant: 'outline', size: 'md' }],
+      ['checkbox', { variant: 'solid', size: 'md' }],
+      ['field', {}],
+    ];
+    for (const [key, variant] of slotCases) {
+      expect(chakraSystem.sva(chakraSystem.getSlotRecipe(key))(variant)).toStrictEqual(
+        defaultSystem.sva(defaultSystem.getSlotRecipe(key))(variant),
+      );
+    }
+  });
+
+  it('drops the recipes nothing renders', () => {
+    // Guards the point of the change: if these come back, the trim regressed.
+    for (const key of ['badge', 'heading', 'kbd', 'link', 'separator', 'skeleton', 'container']) {
+      expect(defaultSystem.isRecipe(key)).toBe(true);
+      expect(chakraSystem.isRecipe(key)).toBe(false);
+    }
+    for (const key of ['menu', 'tabs', 'drawer', 'popover', 'tooltip', 'accordion', 'toast']) {
+      expect(defaultSystem.isSlotRecipe(key)).toBe(true);
+      expect(chakraSystem.isSlotRecipe(key)).toBe(false);
+    }
+  });
+});

--- a/apps/frontend/test/utils.tsx
+++ b/apps/frontend/test/utils.tsx
@@ -1,5 +1,6 @@
 import { render, type RenderOptions } from '@testing-library/react';
-import { ChakraProvider, defaultSystem } from '@chakra-ui/react';
+import { ChakraProvider } from '@chakra-ui/react';
+import { chakraSystem } from '@/lib/chakraSystem';
 import type { ReactElement } from 'react';
 import type { RbacSubject } from '@branch/rbac';
 import { AuthContext, AuthProvider } from '@/context/AuthContext';
@@ -21,7 +22,7 @@ function makeWrapper(subject: RbacSubject | null) {
 
   return function Wrapper({ children }: { children: React.ReactNode }) {
     return (
-      <ChakraProvider value={defaultSystem}>
+      <ChakraProvider value={chakraSystem}>
         <AuthContext.Provider
           value={
             {
@@ -62,7 +63,7 @@ export const renderWithLiveAuth = (
 ) =>
   render(ui, {
     wrapper: ({ children }) => (
-      <ChakraProvider value={defaultSystem}>
+      <ChakraProvider value={chakraSystem}>
         <AuthProvider>{children}</AuthProvider>
       </ChakraProvider>
     ),


### PR DESCRIPTION
## Recommendation: I think we should close this without merging

The change works and is correct, but the measured saving is **16.9 KB gzipped per route** — well under the ~30 KB bar we set for this being worth the churn. Numbers below so you can judge for yourself; I'd rather report a wash than argue it up.

## What it does

`providers.tsx` mounted `<ChakraProvider value={defaultSystem}>`. `defaultSystem` registers all **19 recipes and 54 slot recipes**, and the whole table lands in the shared chunk on every route — including `/dashboard` and `/projects`, which render zero Chakra components and are pure Tailwind.

This rebuilds the same system from `defaultBaseConfig` with only the recipes our components actually resolve, in a new `apps/frontend/src/lib/chakraSystem.ts`. `providers.tsx` changes on one line.

## Component inventory (evidence, not guesswork)

24 files import from `@chakra-ui/react`. Every named import across `src/` and `test/`, deduplicated — **17 unique exports**:

| Import | Recipe key | Notes |
|---|---|---|
| `Button` | `button` | 8 files |
| `Input` | `input` | |
| `Textarea` | `textarea` | `TextInputField` multiline |
| `CloseButton` | `button` | → `IconButton` → `Button`, no recipe of its own |
| `Table` | `table` (slot) | `DataTable`, `TableSkeletonRows` |
| `Dialog` | `dialog` (slot) | 8 files |
| `Select` | `select` (slot) | `DropdownSelector` |
| `NativeSelect` | `nativeSelect` (slot) | `/reports` only |
| `Checkbox` | `checkbox` (slot) | `DataTable`, `ShowPasswordCheckbox` |
| `Field` | `field` (slot) | `TextInputField` |
| `HStack` / `VStack` / `Stack` | — | styled primitives, no recipe |
| `Portal` | — | no recipe |
| `createListCollection` | — | utility |
| `ChakraProvider` / `defaultSystem` | — | the thing being replaced |

Two recipes are needed transitively and are easy to miss — both confirmed by reading the component sources, not memory:

- **`checkmark`** — `Checkbox.Control` imports `../checkmark/checkmark.js`.
- **`spinner`** — `Button` imports `Loader`, which renders `Spinner` when `loading` is set.
- **`icon`** — `Field` imports `../icon/create-icon.js`, and the `Select`/`NativeSelect` indicators render Chakra icons.

Also checked and found absent: no `chakra()` factory calls, no `useDisclosure`, no custom `defineRecipe`/`defineSlotRecipe`, and no `@chakra-ui/*` subpath imports other than `@chakra-ui/react`.

So: **6 recipes** (`button`, `input`, `textarea`, `icon`, `checkmark`, `spinner`) and **6 slot recipes** (`checkbox`, `dialog`, `field`, `nativeSelect`, `select`, `table`).

Everything that is *not* a recipe is kept byte-identical to `defaultSystem`: `conditions`, `utilities` (both from `defaultBaseConfig`), plus `preflight: true`, `globalCss`, `cssVarsPrefix`, `cssVarsRoot`, `breakpoints`, `keyframes`, `tokens`, `semanticTokens`, `textStyles`, `layerStyles`, `animationStyles`. The last three are kept whole because the recipes we keep reference them by name (`textStyle: "md"`, `layerStyle: "disabled"`, `animationStyle: "slide-fade-in"`) and they total only ~6 KB unminified.

## Measured bytes

Real `npm run build` output, Chakra v3.33.0, Next 15.5.4 (Turbopack), `output: 'export'`. Gzip is `gzip -9`. Per-route totals sum every `/_next/static/**.js` referenced by that route's exported HTML.

**The chunk that was carrying the recipe table** (identified by fingerprint: 235 → 99 `colorPalette`, 74 → 20 `chakra`):

| | raw | gzip |
|---|---|---|
| before | 463,949 | 115,107 |
| after | 378,597 | 98,174 |
| **delta** | **−85,352 (−18.4%)** | **−16,933 (−14.7%)** |

**Per-route JS:**

| Route | raw before | raw after | raw delta | gz before | gz after | **gz delta** |
|---|---|---|---|---|---|---|
| `/dashboard` | 1,216,588 | 1,131,164 | −85,424 | 348,673 | 331,740 | **−16,933 (−4.9%)** |
| `/projects` | 1,303,857 | 1,218,433 | −85,424 | 378,114 | 361,181 | **−16,933 (−4.5%)** |
| `/expenses` | 1,379,436 | 1,294,012 | −85,424 | 398,960 | 382,027 | −16,933 |
| `/reports` | 1,295,520 | 1,210,096 | −85,424 | 376,222 | 359,289 | −16,933 |
| `/accounts` | 1,264,604 | 1,179,180 | −85,424 | 366,068 | 349,135 | −16,933 |
| `/donors` | 1,290,408 | 1,204,984 | −85,424 | 375,065 | 358,132 | −16,933 |
| `/login` | 1,220,726 | 1,135,302 | −85,424 | 350,660 | 333,727 | −16,933 |
| `/profile` | 1,299,760 | 1,214,336 | −85,424 | 378,441 | 361,508 | −16,933 |

All exported static JS, raw: 2,280,735 → 2,195,311 (−85,424).

Next's own `First Load JS` column, for cross-reference: shared 300 → 283 kB, `/dashboard` 309 → 293 kB, `/projects` 339 → 322 kB.

The saving is identical on every route because it is entirely in the one shared chunk — which is the point, but also the ceiling. The remaining ~378 KB raw in that chunk is the Chakra/Ark/Zag runtime plus tokens, which trimming recipes cannot touch.

### Why this is a wash

**16.9 KB gzipped, ~4.5–4.9% of route JS.** Below the ~30 KB threshold. Against that: a new module, a new concept for contributors, and a permanent maintenance obligation — every future Chakra component needs its recipe added here or it renders unstyled. My recommendation is to close this and keep `defaultSystem`. If we want real wins on these routes, the bigger targets are the 292 KB and 188 KB non-Chakra chunks.

## Correctness

`npm run typecheck` — clean. `npm run lint` — clean. `npm run build` — clean, 17/17 pages exported.

**Full suite: 36 suites passed, 382 passed, 2 skipped, 384 total** (baseline on `origin/main` is 35 suites / 358 passed / 2 skipped — this PR adds 1 suite and 24 tests).

### Verified by test

`test/lib/chakraSystem.test.ts` pins the trimmed system against `defaultSystem`, because a missing recipe renders unstyled without throwing:

- each of the 12 kept recipes/slot recipes is `toStrictEqual` its `defaultSystem` counterpart;
- `getPreflightCss()`, `getGlobalCss()` and `getTokenCss()` are all identical — this is the one that matters for the Tailwind interaction;
- token resolution spot checks (`colors.blue.500`, `colors.border`, `colors.bg`, `colors.fg`, `spacing.4`, `radii.l2`, `sizes.10`, `fontSizes.md`);
- resolved variant output via `cva`/`sva` for the sizes and variants we actually render;
- and an assertion that the dropped recipes really are absent, so a future regression that quietly reinstates `defaultSystem` fails.

### Verified visually

I built a throwaway harness page mounting every Chakra surface with real data, built it twice — once with `defaultSystem`, once with `chakraSystem` — served both from `out/` on separate ports, and compared. The harness page is **not** part of this PR.

Rendered and compared side by side at 1280×900:

- **Tables** — `DataTable` with row selection, `variant="outline"`, the loading-skeleton state, and a raw `Table.Root`
- **Checkboxes** — `DataTable` header/row checkboxes, `ShowPasswordCheckbox`, raw checked/unchecked/disabled, sizes sm/md/lg
- **Buttons** — all 7 variants, `colorPalette="red"`, sizes xs/sm/lg, disabled, `loading`, `loadingText`, `CloseButton`
- **Inputs** — `TextInputField` in plain/required/error/valid/disabled/prefixed/multiline, raw `Field`+`Input`, raw `Textarea`, `Input` sizes xs/sm/md/lg
- **NativeSelect** — sizes sm and md, placeholder and selected states
- **Select** — `DropdownSelector` closed and **open** (6 items, green selected row, inter-item borders)
- **Dialogs** — plain `Dialog` open (backdrop, header, title, close trigger, body with input + select, footer) and `ConfirmDeleteDialog` open (pale-green chrome, typed-confirmation input, red Delete)
- **Pagination** — `HStack` + `Button`, active page

Beyond eyeballing the two screenshots, I diffed **computed styles** across the whole page between the two builds — 48 CSS properties plus bounding box for all 333 elements:

- element count identical (333), document height identical (3198px), zero elements present in one build and not the other;
- **331 of 333 elements identical on every property and box dimension**;
- the 2 that differ are both the `chakra-spinner` inside the `loading` buttons, differing only in `transform: matrix(...)` — the same emotion class (`css-1pjn8cc`) on both builds, caught at a different frame of its rotation animation. Not a style difference.

**On borders and spacing specifically** (the `!`-prefixed Tailwind risk): no border, padding, margin, gap or radius difference anywhere in the diff, and `getPreflightCss()`/`getGlobalCss()` are identical by test. I also confirmed directly on the open dropdown that the `!` utilities still win over Chakra — computed `border-radius: 4px` from `!rounded`, `box-shadow: none` from `!shadow-none`, `padding: 0px` from `!p-0`, all overriding the `select` slot recipe as before.

### What I did not verify

- The authenticated pages were **not** rendered in their real form. This is a static export with an `AuthGate` and no backend available, so `/dashboard`, `/projects`, `/expenses`, `/reports`, `/accounts`, `/donors`, `/donations` and `/profile` all redirect to `/login` without a session. I verified the components those pages compose, in the harness, rather than the assembled pages. Treat the page-level appearance as covered by test and by component-level rendering, not by direct visual sign-off.
- Hover/focus/active states were not screenshotted, though the recipes producing them are asserted identical.
- Under heavy parallel load from other builds on this machine I saw the suite flake twice (1 and then 6 suites failing) and could not reproduce it in 13 subsequent parallel runs, 5 serial runs, or 12 isolated runs of the new test file. The failures did not name a consistent suite and looked like a timeout cascade rather than a styling bug, but I could not capture one to prove it, so I am flagging it rather than dismissing it.

## Recipe I was least sure about

`spinner`. It is only reachable through `<Button loading>`, and nothing in `src/` currently passes `loading`. I kept it because `Button` imports `Loader` unconditionally, so the recipe lookup would happen the moment anyone uses the prop, and it costs 945 bytes unminified. If you wanted to be aggressive you could drop it, but the failure mode is an unstyled spinner appearing months later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
