### PR TITLE
test(lambdas): close the module-level db pool so jest exits

### DIFF
--- a/apps/backend/lambdas/donors/test/donors.test.ts
+++ b/apps/backend/lambdas/donors/test/donors.test.ts
@@ -1,6 +1,7 @@
 import { Pool } from 'pg';
 import { ensureSchema, resetData } from '../../../db/testkit';
 import { handler } from '../handler';
+import db from '../db';
 jest.mock('../auth', () => {
   // dispatch() resolves the caller through resolveAuth, so an auto-mock would
   // hand it `undefined` and every route would 500. Only the authenticate half
@@ -658,6 +659,7 @@ describe("Donor API when DB is empty", () => {
 
 afterAll(async () => {
   await pool.end();
+  await db.destroy();
 });
 
 

--- a/apps/backend/lambdas/expenditures/test/expenditures.e2e.test.ts
+++ b/apps/backend/lambdas/expenditures/test/expenditures.e2e.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeAll, beforeEach, afterAll, jest } from '@jest/globals';
 import { Pool } from 'pg';
 import { ensureSchema, resetData } from '../../../db/testkit';
+import db from '../db';
 
 // mock auth only for now
 jest.mock('../auth', () => {
@@ -182,6 +183,7 @@ describe('Expenditures integration tests', () => {
 
   afterAll(async () => {
     await pool.end();
+    await db.destroy();
   });
 
   describe('Health check', () => {

--- a/apps/backend/lambdas/projects/test/crud.test.ts
+++ b/apps/backend/lambdas/projects/test/crud.test.ts
@@ -97,6 +97,7 @@ beforeEach(async () => {
 
 afterAll(async () => {
   await pool.end();
+  await db.destroy();
 });
 
 test("health test 🌞", async () => {

--- a/apps/backend/lambdas/reports/test/reports.e2e.test.ts
+++ b/apps/backend/lambdas/reports/test/reports.e2e.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeAll, beforeEach, afterAll, jest } from '@jest/globals';
 import { Pool } from 'pg';
 import { ensureSchema, resetData } from '../../../db/testkit';
+import db from '../db';
 
 jest.mock('../auth', () => {
   // dispatch() resolves the caller through resolveAuth, so an auto-mock would
@@ -97,6 +98,7 @@ describe('Reports e2e tests', () => {
 
   afterAll(async () => {
     await pool.end();
+    await db.destroy();
   });
 
   describe('Health check', () => {

--- a/apps/backend/lambdas/users/test/users.test.ts
+++ b/apps/backend/lambdas/users/test/users.test.ts
@@ -14,6 +14,7 @@ jest.mock('@aws-sdk/client-cognito-identity-provider', () => {
 
 import { Pool } from 'pg';
 import { ensureSchema, resetData } from '../../../db/testkit';
+import db from '../db';
 import { handler } from '../handler';
 import { authenticateRequest } from '../auth';
 
@@ -92,7 +93,7 @@ beforeEach(async () => {
 
 afterAll(async () => {
   await pool.end();
-  await new Promise(resolve => setTimeout(resolve, 500));
+  await db.destroy();
 });
 
 


### PR DESCRIPTION
## The hang

```
Tests:       60 passed, 60 total
Time:        3.905 s
Ran all test suites.
Jest did not exit one second after the test run has completed.
```

Every lambda's `db.ts` builds a module-scoped Kysely instance whose pg Pool is tuned for lambda's freeze/thaw cycle:

```ts
idleTimeoutMillis: 0,
keepAlive: true,
```

`idleTimeoutMillis: 0` means an idle socket is never reaped. Importing the handler in a test constructs that pool, and five suites ended only their own fixture `pool` in `afterAll` — they never called `db.destroy()`. That live socket is the open handle. Jest prints the warning and then waits on it rather than exiting, so the CI job hangs on a run that already went green.

## The fix

`await db.destroy()` in `afterAll`, alongside the existing `await pool.end()`:

- `donors/test/donors.test.ts`
- `projects/test/crud.test.ts`
- `expenditures/test/expenditures.e2e.test.ts`
- `reports/test/reports.e2e.test.ts`
- `users/test/users.test.ts`

Six suites already did this (`projects/*.unit`, `projects/*.e2e`, `reports/report-service.e2e`) — this brings the rest in line rather than introducing a new pattern. Suites that only `jest.mock('../db')` never build a real pool, so they need no teardown and are untouched.

`users.test.ts` also had `await new Promise(resolve => setTimeout(resolve, 500))` in `afterAll` — a band-aid for this same leak that delayed the hang instead of fixing it. Removed.

No `--forceExit`: that hides the leak instead of closing it, and would mask a genuinely stuck query later.

## Verification

Not run locally. This worktree's `node_modules` are symlinked from the shared checkout, so `@branch/lambda-http` and `@branch/lambda-auth` resolve to that checkout's stale `dist/` — `createAuthResolver` and `loadRbacSubject` are missing from it, and every suite fails to load for that reason, before any of this diff is reached. Environmental, unrelated to the change. CI installs fresh and builds `shared/`, so it is the real check here — the warning should be gone from the donors and projects jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
