### PR TITLE
feat(projects): pick each member's project role in the staff picker

### DIFF
--- a/apps/frontend/src/app/components/DropdownSelector.tsx
+++ b/apps/frontend/src/app/components/DropdownSelector.tsx
@@ -17,6 +17,8 @@ interface DropdownSelectorProps {
   value?: string | string[];
   onChange?: (value: string | string[]) => void;
   hideTrigger?: boolean;
+  disabled?: boolean;
+  ariaLabel?: string;
 }
 
 export default function DropdownSelector({
@@ -26,6 +28,8 @@ export default function DropdownSelector({
   value,
   onChange,
   hideTrigger = false,
+  disabled = false,
+  ariaLabel,
 }: DropdownSelectorProps) {
   const collection = useMemo(
     () =>
@@ -50,12 +54,14 @@ export default function DropdownSelector({
       <Select.Root
         collection={collection}
         multiple={multiSelect}
+        disabled={disabled}
         value={controlledValue}
         onValueChange={handleValueChange}
         open={hideTrigger ? true : undefined}
         closeOnSelect={!multiSelect && !hideTrigger}
       >
         <Select.Trigger
+          aria-label={ariaLabel}
           style={
             hideTrigger
               ? {
@@ -74,7 +80,7 @@ export default function DropdownSelector({
           className={
             hideTrigger
               ? ''
-              : 'flex !w-full items-center justify-between !rounded !border !border-black-200 !bg-core-white !px-3 !py-2 !h-10 cursor-pointer !shadow-none !text-black-700 !font-body !text-body'
+              : 'flex !w-full items-center justify-between !rounded !border !border-black-200 !bg-core-white !px-3 !py-2 !h-10 cursor-pointer !shadow-none !text-black-700 !font-body !text-body data-[disabled]:cursor-not-allowed data-[disabled]:!opacity-60'
           }
         >
           {!hideTrigger && (

--- a/apps/frontend/src/app/components/ProjectFormModal.tsx
+++ b/apps/frontend/src/app/components/ProjectFormModal.tsx
@@ -7,7 +7,12 @@ import TextInputField from './TextInputField';
 import DatePickerField from './DatePickerField';
 import StaffPicker from './StaffPicker';
 import { useApi } from '@/hooks/useApi';
-import type { AssignableStaff, Member, Project } from '@/types';
+import type {
+  AssignableStaff,
+  Member,
+  MemberAssignment,
+  Project,
+} from '@/types';
 
 export interface ProjectFormValues {
   name: string;
@@ -16,7 +21,7 @@ export interface ProjectFormValues {
   startDate: string;
   endDate: string;
   inProgress: boolean;
-  memberIds: number[];
+  members: MemberAssignment[];
 }
 
 interface ProjectFormModalProps {
@@ -42,7 +47,7 @@ const EMPTY_VALUES: ProjectFormValues = {
   startDate: '',
   endDate: '',
   inProgress: false,
-  memberIds: [],
+  members: [],
 };
 
 /** Strips `$` and thousands separators so `$30,000` is accepted as typed. */
@@ -79,8 +84,8 @@ function validate(values: ProjectFormValues): FieldErrors {
     }
   }
 
-  if (values.memberIds.length === 0) {
-    errors.memberIds = 'Select AT LEAST 1 staff member for the project';
+  if (values.members.length === 0) {
+    errors.members = 'Select AT LEAST 1 staff member for the project';
   }
 
   return errors;
@@ -136,7 +141,10 @@ export default function ProjectFormModal({
             startDate: project.start_date?.slice(0, 10) ?? '',
             endDate: project.end_date?.slice(0, 10) ?? '',
             inProgress: !project.end_date,
-            memberIds: members.map((m) => m.user_id),
+            members: members.map((m) => ({
+              user_id: m.user_id,
+              role: m.role,
+            })),
           }
         : EMPTY_VALUES,
     );
@@ -201,7 +209,7 @@ export default function ProjectFormModal({
       total_budget: parseBudget(values.budget),
       start_date: values.startDate || null,
       end_date: values.inProgress ? null : values.endDate || null,
-      members: values.memberIds,
+      members: values.members,
     };
 
     try {
@@ -336,10 +344,10 @@ export default function ProjectFormModal({
                   required
                   options={staff}
                   isLoading={staffLoading}
-                  value={values.memberIds}
-                  onChange={(v) => update('memberIds', v)}
-                  isError={showError('memberIds')}
-                  errorMessage={errors.memberIds}
+                  value={values.members}
+                  onChange={(v) => update('members', v)}
+                  isError={showError('members')}
+                  errorMessage={errors.members}
                   disabled={saving}
                 />
 

--- a/apps/frontend/src/app/components/StaffPicker.tsx
+++ b/apps/frontend/src/app/components/StaffPicker.tsx
@@ -3,18 +3,27 @@
 import { useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { LuSearch, LuX } from 'react-icons/lu';
-import type { AssignableStaff } from '@/types';
+import {
+  DEFAULT_PROJECT_ROLE,
+  PROJECT_ROLES,
+  type AssignableStaff,
+  type MemberAssignment,
+  type ProjectRole,
+} from '@/types';
 import { useAnchoredPopover } from '@/hooks/useAnchoredPopover';
+import DropdownSelector from './DropdownSelector';
 import LoadingState from './LoadingState';
 
 const LISTBOX_MAX_HEIGHT = 220;
 
+const ROLE_OPTIONS: string[] = [...PROJECT_ROLES];
+
 interface StaffPickerProps {
   label: string;
   options: AssignableStaff[];
-  /** Selected user ids, in the order they were added. */
-  value: number[];
-  onChange: (value: number[]) => void;
+  /** Selected staff and the role each holds, in the order they were added. */
+  value: MemberAssignment[];
+  onChange: (value: MemberAssignment[]) => void;
   placeholder?: string;
   required?: boolean;
   disabled?: boolean;
@@ -25,7 +34,7 @@ interface StaffPickerProps {
 
 /**
  * Search-and-select list of staff, rendering the chosen people as removable
- * chips beneath the field.
+ * rows beneath the field, each with the project role they will hold.
  *
  * Filtering happens client-side against the full roster: the staff list is
  * organisation-sized (tens, not thousands), so a request per keystroke would
@@ -64,30 +73,45 @@ export default function StaffPicker({
   const selected = useMemo(
     () =>
       value
-        .map((id) => byId.get(id))
-        .filter((s): s is AssignableStaff => Boolean(s)),
+        .map((assignment) => {
+          const person = byId.get(assignment.user_id);
+          return person ? { person, role: assignment.role } : null;
+        })
+        .filter((entry) => entry !== null),
     [value, byId],
+  );
+
+  const selectedIds = useMemo(
+    () => new Set(value.map((assignment) => assignment.user_id)),
+    [value],
   );
 
   const matches = useMemo(() => {
     const needle = query.trim().toLowerCase();
     return options.filter((option) => {
-      if (value.includes(option.user_id)) return false;
+      if (selectedIds.has(option.user_id)) return false;
       if (!needle) return true;
       return (
         option.name.toLowerCase().includes(needle) ||
         option.email.toLowerCase().includes(needle)
       );
     });
-  }, [options, query, value]);
+  }, [options, query, selectedIds]);
 
   const add = (id: number) => {
-    onChange([...value, id]);
+    onChange([...value, { user_id: id, role: DEFAULT_PROJECT_ROLE }]);
     setQuery('');
   };
 
   const remove = (id: number) =>
-    onChange(value.filter((existing) => existing !== id));
+    onChange(value.filter((assignment) => assignment.user_id !== id));
+
+  const setRole = (id: number, role: ProjectRole) =>
+    onChange(
+      value.map((assignment) =>
+        assignment.user_id === id ? { ...assignment, role } : assignment,
+      ),
+    );
 
   const labelClass = isError ? '!text-error-red' : '!text-core-black';
   const boxClass = isError ? '!border-error-red' : '!border-black-400';
@@ -173,23 +197,42 @@ export default function StaffPicker({
       </div>
 
       {selected.length > 0 && (
-        <ul className="flex flex-wrap !gap-2" aria-label={`Selected ${label}`}>
-          {selected.map((person) => (
-            <li key={person.user_id}>
-              <span className="inline-flex items-center !gap-1.5 rounded-[18px] bg-black-300 !px-2.5 !py-1">
-                <small className="!font-bold !text-core-black">
+        <ul className="flex flex-col !gap-2" aria-label={`Selected ${label}`}>
+          {selected.map(({ person, role }) => (
+            <li
+              key={person.user_id}
+              className="flex items-center !gap-3 rounded-[4px] bg-black-300 !px-3 !py-2"
+            >
+              <div className="min-w-0 flex-1">
+                <small className="block truncate !font-bold !text-core-black">
                   {person.name}
                 </small>
-                <button
-                  type="button"
+                <small className="block truncate !text-black-700">
+                  {person.email}
+                </small>
+              </div>
+
+              <div className="w-[130px] shrink-0">
+                <DropdownSelector
+                  options={ROLE_OPTIONS}
+                  value={role}
                   disabled={disabled}
-                  onClick={() => remove(person.user_id)}
-                  aria-label={`Remove ${person.name}`}
-                  className="flex cursor-pointer items-center justify-center text-core-black disabled:cursor-not-allowed"
-                >
-                  <LuX size={11} aria-hidden />
-                </button>
-              </span>
+                  ariaLabel={`Role for ${person.name}`}
+                  onChange={(next) =>
+                    setRole(person.user_id, next as ProjectRole)
+                  }
+                />
+              </div>
+
+              <button
+                type="button"
+                disabled={disabled}
+                onClick={() => remove(person.user_id)}
+                aria-label={`Remove ${person.name}`}
+                className="flex shrink-0 cursor-pointer items-center justify-center text-core-black disabled:cursor-not-allowed"
+              >
+                <LuX size={14} aria-hidden />
+              </button>
             </li>
           ))}
         </ul>

--- a/apps/frontend/src/app/projects/ProjectDetailView.tsx
+++ b/apps/frontend/src/app/projects/ProjectDetailView.tsx
@@ -185,6 +185,7 @@ export default function ProjectDetailView({ id }: { id: string }) {
                       key={member.user_id}
                       compact
                       name={member.name}
+                      title={member.role}
                       email={member.email}
                       image={member.profile_image ?? undefined}
                     />

--- a/apps/frontend/src/types/project.ts
+++ b/apps/frontend/src/types/project.ts
@@ -1,3 +1,8 @@
+import {
+  DEFAULT_PROJECT_ROLE,
+  PROJECT_ROLES,
+  type ProjectRole,
+} from '@branch/rbac';
 import type { Expenditure } from './expenditure';
 
 export interface Project {
@@ -11,8 +16,7 @@ export interface Project {
     created_at: string | null;
 };
 
-export const PROJECT_ROLES = ['Admin', 'Director', 'Student'] as const;
-export type ProjectRole = (typeof PROJECT_ROLES)[number];
+export { DEFAULT_PROJECT_ROLE, PROJECT_ROLES, type ProjectRole };
 
 export interface Member {
   user_id: number;
@@ -66,6 +70,11 @@ export interface AssignableStaff {
   profile_image?: string | null;
 }
 
+export interface MemberAssignment {
+  user_id: number;
+  role: ProjectRole;
+}
+
 /** Body accepted by `POST /projects` and `PUT /projects/{id}`. */
 export interface ProjectWriteBody {
   name: string;
@@ -73,5 +82,5 @@ export interface ProjectWriteBody {
   total_budget: string | null;
   start_date: string | null;
   end_date: string | null;
-  members: number[];
+  members: MemberAssignment[];
 }

--- a/apps/frontend/test/components/ProjectFormModal.test.tsx
+++ b/apps/frontend/test/components/ProjectFormModal.test.tsx
@@ -1,0 +1,172 @@
+import { render, screen, fireEvent, waitFor, within } from '../utils';
+import ProjectFormModal from '@/app/components/ProjectFormModal';
+import { authedFetch } from '@/lib/authClient';
+import type { Member, Project } from '@/types';
+
+jest.mock('../../src/lib/authClient', () => ({
+  ...jest.requireActual('../../src/lib/authClient'),
+  authedFetch: jest.fn(),
+}));
+
+jest.mock('../../src/app/components/DropdownSelector', () => {
+  return function MockDropdownSelector({
+    options,
+    value,
+    onChange,
+    ariaLabel,
+    placeholder,
+    disabled,
+  }: {
+    options: string[];
+    value?: string;
+    onChange?: (v: string) => void;
+    ariaLabel?: string;
+    placeholder?: string;
+    disabled?: boolean;
+  }) {
+    return (
+      <select
+        aria-label={ariaLabel ?? placeholder}
+        value={value ?? ''}
+        disabled={disabled}
+        onChange={(e) => onChange?.(e.target.value)}
+      >
+        {options.map((o) => (
+          <option key={o} value={o}>
+            {o}
+          </option>
+        ))}
+      </select>
+    );
+  };
+});
+
+const mockFetch = authedFetch as jest.MockedFunction<typeof authedFetch>;
+
+const STAFF = [
+  { user_id: 1, name: 'Ada Lovelace', email: 'ada@branch.org' },
+  { user_id: 2, name: 'Grace Hopper', email: 'grace@branch.org' },
+];
+
+const PROJECT: Project = {
+  project_id: 7,
+  name: 'Clean Water',
+  description: 'Wells and pumps',
+  total_budget: '30000',
+  start_date: '2025-01-01',
+  end_date: '2025-12-31',
+  currency: 'USD',
+  created_at: '2025-01-01T00:00:00.000Z',
+};
+
+const MEMBERS: Member[] = [
+  {
+    user_id: 1,
+    name: 'Ada Lovelace',
+    email: 'ada@branch.org',
+    role: 'Director',
+  },
+];
+
+function savedBody() {
+  const write = mockFetch.mock.calls.find(
+    ([, init]) => init?.method === 'PUT' || init?.method === 'POST',
+  );
+  return JSON.parse((write![1] as { body: string }).body);
+}
+
+function renderEdit() {
+  return render(
+    <ProjectFormModal
+      open
+      onClose={jest.fn()}
+      onSaved={jest.fn()}
+      project={PROJECT}
+      members={MEMBERS}
+    />,
+  );
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  mockFetch.mockImplementation((path: string) => {
+    if (path === '/projects/assignable-staff') {
+      return Promise.resolve({ staff: STAFF } as never);
+    }
+    return Promise.resolve(PROJECT as never);
+  });
+});
+
+describe('ProjectFormModal staff roles', () => {
+  it('seeds each assigned member with the role they already hold', async () => {
+    renderEdit();
+
+    const roleSelect = await screen.findByLabelText<HTMLSelectElement>(
+      'Role for Ada Lovelace',
+    );
+    expect(roleSelect.value).toBe('Director');
+  });
+
+  it('saves the role picked for an existing member', async () => {
+    renderEdit();
+
+    const roleSelect = await screen.findByLabelText('Role for Ada Lovelace');
+    fireEvent.change(roleSelect, { target: { value: 'Admin' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(
+        mockFetch.mock.calls.some(([, init]) => init?.method === 'PUT'),
+      ).toBe(true);
+    });
+    expect(savedBody().members).toEqual([{ user_id: 1, role: 'Admin' }]);
+  });
+
+  it('starts a newly picked member at the default role and posts it', async () => {
+    renderEdit();
+
+    const search = await screen.findByLabelText('Assigned Staff');
+    fireEvent.change(search, { target: { value: 'Grace' } });
+    fireEvent.click(
+      await screen.findByRole('option', { name: 'Grace Hopper' }),
+    );
+
+    const added = await screen.findByLabelText<HTMLSelectElement>(
+      'Role for Grace Hopper',
+    );
+    expect(added.value).toBe('Student');
+
+    fireEvent.change(added, { target: { value: 'Director' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(
+        mockFetch.mock.calls.some(([, init]) => init?.method === 'PUT'),
+      ).toBe(true);
+    });
+    expect(savedBody().members).toEqual([
+      { user_id: 1, role: 'Director' },
+      { user_id: 2, role: 'Director' },
+    ]);
+  });
+
+  it('drops a removed member from the roster it saves', async () => {
+    renderEdit();
+
+    const list = await screen.findByRole('list', {
+      name: 'Selected Assigned Staff',
+    });
+    fireEvent.click(
+      within(list).getByRole('button', { name: 'Remove Ada Lovelace' }),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(
+      await screen.findByText('Select AT LEAST 1 staff member for the project'),
+    ).toBeInTheDocument();
+    expect(
+      mockFetch.mock.calls.some(([, init]) => init?.method === 'PUT'),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

The UI gave no way to say what role someone holds on a project. The projects API has accepted `[{ user_id, role }]` since roles were introduced (`validateMembers`, `apps/backend/lambdas/projects/validation-utils.ts`), but `ProjectFormModal` posted `members: number[]`, so every assignment fell through to the API's `Student` default.

Editing was the sharper edge: seeding the form dropped `member.role` entirely, so a save re-sent bare ids and relied on `syncMemberships`' "keep the role they already held" fallback. Correct by accident, and impossible to change a role through.

## Change

- `StaffPicker` carries a `MemberAssignment` per person instead of a user id. The selected chips become rows: name + email, a role dropdown, and the remove button. New picks start at `DEFAULT_PROJECT_ROLE`, which is exactly what the API would have applied on its own.
- `ProjectFormModal` seeds each row from the role that member already holds and posts the assignments as-is.
- `ProjectDetailView` renders the role beside the name via the `title` slot `StaffCard` already had, so a role you set is visible without reopening the form.
- `types/project.ts` re-exports `PROJECT_ROLES` / `ProjectRole` / `DEFAULT_PROJECT_ROLE` from `@branch/rbac` instead of keeping the second copy that had grown there — the same re-export the projects lambda does, so the picker's options and the values the API accepts cannot drift.
- `DropdownSelector` gains `disabled` and `ariaLabel`. Its own doc comment already anticipated "callers that repeat the control per row, where the visible label is the row rather than the field"; this is that caller.

No backend, schema, or `@branch/rbac` changes — the API side was already there.

## Tests

New `test/components/ProjectFormModal.test.tsx` (4 cases): existing members seed with the role they hold, a changed role reaches the request body, a newly picked member defaults to `Student` and posts whatever it is changed to, and a removed member drops out of the roster.

Verified locally in `apps/frontend`: `tsc --noEmit` clean, `next lint` clean, `npm run build` green, full jest suite 38/38 suites and 366 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)