### PR TITLE
fix(lambdas): report caught 500s to Sentry instead of swallowing them

### DIFF
--- a/apps/backend/lambdas/AGENTS.md
+++ b/apps/backend/lambdas/AGENTS.md
@@ -51,6 +51,7 @@ export const getDonor: RouteHandler = async ({ params }) => {
 };
 ```
 - `dispatch()` handles OPTIONS preflight, `GET /<prefix>/health`, 404 and 500 centrally — routes.ts only lists real endpoints.
+- **A caught error is an error Sentry cannot see.** The Sentry layer wraps the handler and records uncaught throws only, and we always catch so API Gateway returns a JSON 500 instead of a 502. `dispatch()` reports what reaches its catch; a controller that returns its own 500 must use `serverError(err, 'Failed to …')` from `@branch/lambda-http` rather than `console.error` + `json(500, …)`. Same status to the caller, one less invisible failure.
 - **NEVER remove or modify the `ROUTES-START` / `ROUTES-END` markers** — the CLI inserts new table entries between them.
 - Patterns are always full-prefixed (`/donors/:id`, never `/:id`) so one table works whether the event arrives via API Gateway's `{proxy+}` (full path) or the shared dev-server (prefix stripped) — `dispatch()` canonicalizes both to the prefixed form.
 - Responses go through `json(status, body)` from `@branch/lambda-http`, which sets CORS headers (`Access-Control-Allow-Origin: *`, allowed headers `Content-Type,Authorization`). See `shared/lambda-http/README.md` for the full API (`parseBody`, `requirePermission`, `createAuthResolver`, `matchPattern`).

--- a/apps/backend/lambdas/auth/controllers/auth.ts
+++ b/apps/backend/lambdas/auth/controllers/auth.ts
@@ -7,7 +7,7 @@ import {
   GlobalSignOutCommandInput,
   ChallengeNameType,
 } from '@aws-sdk/client-cognito-identity-provider';
-import { json, parseBody } from '@branch/lambda-http';
+import { json, parseBody, reportError, serverError } from '@branch/lambda-http';
 import type { RouteHandler } from '@branch/lambda-http';
 import { authenticateRequest } from '../auth';
 import db from '../db';
@@ -78,7 +78,10 @@ export async function handleLogin(event: any): Promise<APIGatewayProxyResult> {
       return challengeResponse(response);
     }
 
-    return json(500, { message: 'Unexpected response from authentication service' });
+    return serverError(
+      new Error('Cognito returned neither AuthenticationResult nor a challenge'),
+      'Unexpected response from authentication service',
+    );
   } catch (error: any) {
     return mapCognitoAuthError(error, 'login');
   }
@@ -142,7 +145,10 @@ export async function handleRespondChallenge(event: any): Promise<APIGatewayProx
     if (response.ChallengeName) {
       return challengeResponse(response);
     }
-    return json(500, { message: 'Unexpected response from authentication service' });
+    return serverError(
+      new Error('Cognito returned neither AuthenticationResult nor a challenge'),
+      'Unexpected response from authentication service',
+    );
   } catch (error: any) {
     return mapCognitoAuthError(error, 'challenge');
   }
@@ -262,6 +268,7 @@ export async function handleLogout(event: any): Promise<APIGatewayProxyResult> {
       return json(401, { message: 'Invalid or expired token' });
     }
 
+    reportError(error);
     return json(500, { message: 'Failed to logout' });
   }
 }

--- a/apps/backend/lambdas/auth/controllers/mfa.ts
+++ b/apps/backend/lambdas/auth/controllers/mfa.ts
@@ -5,7 +5,7 @@ import {
   SetUserMFAPreferenceCommand,
   GetUserCommand,
 } from '@aws-sdk/client-cognito-identity-provider';
-import { json, parseBody } from '@branch/lambda-http';
+import { json, parseBody, reportError, serverError } from '@branch/lambda-http';
 import type { RouteHandler } from '@branch/lambda-http';
 import db from '../db';
 import { cognitoClient } from '../services/cognito';
@@ -43,6 +43,7 @@ function mapMfaError(error: any): APIGatewayProxyResult {
     case 'LimitExceededException':
       return json(429, { message: 'Too many attempts, please try again later', code });
     default:
+      reportError(error, { code });
       return json(500, { message: 'MFA request failed', error: error?.message, code });
   }
 }
@@ -80,7 +81,10 @@ export const handleMfaSetup: RouteHandler = async ({ event, auth }) => {
 
     const secretCode = response.SecretCode;
     if (!secretCode) {
-      return json(500, { message: 'Failed to generate MFA secret' });
+      return serverError(
+        new Error('AssociateSoftwareToken returned no SecretCode'),
+        'Failed to generate MFA secret',
+      );
     }
 
     const label = encodeURIComponent(`BRANCH:${me?.email ?? user.cognitoSub}`);

--- a/apps/backend/lambdas/auth/controllers/password.ts
+++ b/apps/backend/lambdas/auth/controllers/password.ts
@@ -5,7 +5,7 @@ import {
   ConfirmForgotPasswordCommand,
   ConfirmForgotPasswordCommandInput,
 } from '@aws-sdk/client-cognito-identity-provider';
-import { json } from '@branch/lambda-http';
+import { json, reportError } from '@branch/lambda-http';
 import { cognitoClient, USER_POOL_CLIENT_ID } from '../services/cognito';
 
 export async function handleForgotPassword(event: any): Promise<APIGatewayProxyResult> {
@@ -39,6 +39,7 @@ export async function handleForgotPassword(event: any): Promise<APIGatewayProxyR
     if (error.name === 'InvalidParameterException') {
       return json(400, { message: 'Cannot reset password for unverified email. Please verify your email first.' });
     }
+    reportError(error);
     return json(500, { message: 'Failed to initiate password reset' });
   }
 }
@@ -77,6 +78,7 @@ export async function handleResetPassword(event: any): Promise<APIGatewayProxyRe
     if (error.name === 'LimitExceededException') {
       return json(429, { message: 'Too many attempts, please try again later' });
     }
+    reportError(error);
     return json(500, { message: 'Failed to reset password' });
   }
 }

--- a/apps/backend/lambdas/auth/controllers/register.ts
+++ b/apps/backend/lambdas/auth/controllers/register.ts
@@ -8,7 +8,7 @@ import {
   ConfirmSignUpCommandInput,
   ResendConfirmationCodeCommand,
 } from '@aws-sdk/client-cognito-identity-provider';
-import { json } from '@branch/lambda-http';
+import { json, reportError, serverError } from '@branch/lambda-http';
 import db from '../db';
 import { cognitoClient, USER_POOL_CLIENT_ID, USER_POOL_ID, validatePassword } from '../services/cognito';
 
@@ -143,6 +143,7 @@ export async function handleRegister(event: any): Promise<APIGatewayProxyResult>
             }
           } catch (linkError) {
             console.warn('Could not auto-link existing Cognito user:', linkError);
+            reportError(linkError, { email: (email as string).toLowerCase() });
           }
         }
         return json(409, {
@@ -157,6 +158,7 @@ export async function handleRegister(event: any): Promise<APIGatewayProxyResult>
         return json(400, { message: error.message || 'Invalid parameters provided' });
       }
 
+      reportError(error);
       return json(500, { message: 'Failed to register user in authentication service' });
     }
 
@@ -170,7 +172,9 @@ export async function handleRegister(event: any): Promise<APIGatewayProxyResult>
         );
         console.log('Rolled back Cognito user after database failure');
       } catch (rollbackError) {
+        // The Cognito user is now orphaned: no DB row, no way to sign up again.
         console.error('Failed to rollback Cognito user:', rollbackError);
+        reportError(rollbackError, { email: email.toLowerCase() });
       }
     };
 
@@ -206,6 +210,7 @@ export async function handleRegister(event: any): Promise<APIGatewayProxyResult>
       // Rollback: Delete user from Cognito if database insert fails
       await rollbackCognitoUser();
 
+      reportError(dbError);
       return json(500, { message: 'Failed to create user account' });
     }
 
@@ -219,8 +224,7 @@ export async function handleRegister(event: any): Promise<APIGatewayProxyResult>
       claimed: true,
     });
   } catch (error: any) {
-    console.error('Registration error:', error);
-    return json(500, { message: 'Internal server error during registration' });
+    return serverError(error, 'Internal server error during registration');
   }
 }
 
@@ -251,6 +255,7 @@ export async function handleVerifyEmail(event: any): Promise<APIGatewayProxyResu
     if (error.name === 'LimitExceededException') {
       return json(429, { message: 'Too many attempts, please try again later' });
     }
+    reportError(error);
     return json(500, { message: 'Failed to verify email' });
   }
   return json(200, { message: `Email verified successfully for ${email}` });
@@ -278,7 +283,6 @@ export async function handleResendCode(event: any): Promise<APIGatewayProxyResul
     if (error.name === 'LimitExceededException') {
       return json(429, { message: 'Too many attempts, please try again later' });
     }
-    console.error('Resend code error:', error);
-    return json(500, { message: 'Failed to resend verification code' });
+    return serverError(error, 'Failed to resend verification code');
   }
 }

--- a/apps/backend/lambdas/auth/package.json
+++ b/apps/backend/lambdas/auth/package.json
@@ -7,7 +7,7 @@
     "dev": "ts-node --transpile-only dev-server.ts",
     "build": "tsc",
     "test": "start-server-and-test dev http-get://localhost:3000/auth/health jest",
-    "package": "esbuild handler.ts --bundle --platform=node --target=node20 --minify '--external:@aws-sdk/*' --outfile=dist/handler.js && cd dist && zip -q ../lambda.zip handler.js"
+    "package": "esbuild handler.ts --bundle --platform=node --target=node20 --minify '--external:@aws-sdk/*' --external:@sentry/aws-serverless --outfile=dist/handler.js && cd dist && zip -q ../lambda.zip handler.js"
   },
   "devDependencies": {
     "@branch/types": "file:../../../../shared/types",

--- a/apps/backend/lambdas/auth/photos.ts
+++ b/apps/backend/lambdas/auth/photos.ts
@@ -1,5 +1,6 @@
 import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { reportError } from '@branch/lambda-http';
 
 const REGION = process.env.AWS_REGION ?? 'us-east-2';
 const BUCKET = process.env.REPORTS_BUCKET_NAME ?? '';
@@ -27,7 +28,10 @@ export async function resolveProfileImage(
     return await getSignedUrl(s3, new GetObjectCommand({ Bucket: BUCKET, Key: stored }), {
       expiresIn: 900,
     });
-  } catch {
+  } catch (err) {
+    // Degrading to a broken <img> is deliberate, but a bucket or IAM problem
+    // that breaks every avatar should still be visible somewhere.
+    reportError(err, { key: stored });
     return stored;
   }
 }

--- a/apps/backend/lambdas/auth/services/cognito.ts
+++ b/apps/backend/lambdas/auth/services/cognito.ts
@@ -5,7 +5,7 @@ import {
   InitiateAuthCommandOutput,
   RespondToAuthChallengeCommandOutput,
 } from '@aws-sdk/client-cognito-identity-provider';
-import { json } from '@branch/lambda-http';
+import { json, reportError } from '@branch/lambda-http';
 
 // Initialize Cognito client (region defaults to us-east-2)
 export const cognitoClient = new CognitoIdentityProviderClient({
@@ -157,6 +157,10 @@ export function mapCognitoAuthError(
     case 'ForbiddenException':
       return json(403, { message: 'Request blocked', code });
     default:
+      // Every other arm is an expected Cognito outcome; this one is a genuine
+      // failure, and the Sentry layer never sees it because we answer with a
+      // 500 instead of throwing.
+      reportError(error, { stage, code });
       return json(500, { message: 'Authentication failed', error: error?.message, code });
   }
 }

--- a/apps/backend/lambdas/donors/controllers/donors.ts
+++ b/apps/backend/lambdas/donors/controllers/donors.ts
@@ -1,5 +1,5 @@
 import type { RouteCtx } from '@branch/lambda-http';
-import { json } from '@branch/lambda-http';
+import { json, serverError } from '@branch/lambda-http';
 import db from '../db';
 import { DonorValidationUtils } from '../validation-utils';
 
@@ -77,8 +77,7 @@ export async function createDonor({ event }: RouteCtx) {
       })
       .executeTakeFirst();
   } catch (err) {
-    console.error('Database insert error:', err);
-    return json(500, { message: 'Failed to create donor' });
+    return serverError(err, 'Failed to create donor');
   }
 
   return json(201, {

--- a/apps/backend/lambdas/donors/package.json
+++ b/apps/backend/lambdas/donors/package.json
@@ -7,7 +7,7 @@
     "dev": "ts-node --transpile-only dev-server.ts",
     "build": "tsc",
     "test": "jest",
-    "package": "esbuild handler.ts --bundle --platform=node --target=node20 --minify '--external:@aws-sdk/*' --outfile=dist/handler.js && cd dist && zip -q ../lambda.zip handler.js"
+    "package": "esbuild handler.ts --bundle --platform=node --target=node20 --minify '--external:@aws-sdk/*' --external:@sentry/aws-serverless --outfile=dist/handler.js && cd dist && zip -q ../lambda.zip handler.js"
   },
   "devDependencies": {
     "@branch/types": "file:../../../../shared/types",

--- a/apps/backend/lambdas/expenditures/controllers/expenditures.ts
+++ b/apps/backend/lambdas/expenditures/controllers/expenditures.ts
@@ -1,5 +1,5 @@
 import type { RouteHandler } from '@branch/lambda-http';
-import { json, requirePermission } from '@branch/lambda-http';
+import { json, requirePermission, serverError } from '@branch/lambda-http';
 import { can } from '@branch/rbac';
 import type { ExpenseResource } from '@branch/rbac';
 import { ExpenditureValidationUtils } from '../validation-utils';
@@ -122,8 +122,7 @@ export const createExpenditure: RouteHandler = async ({ event, auth }) => {
       spent_on: spentOn ? new Date(spentOn) : new Date(),
     });
   } catch (err) {
-    console.error('Database insert error:', err);
-    return json(500, { message: 'Failed to create expenditure' });
+    return serverError(err, 'Failed to create expenditure');
   }
 
   return json(201, {

--- a/apps/backend/lambdas/expenditures/package.json
+++ b/apps/backend/lambdas/expenditures/package.json
@@ -8,7 +8,7 @@
     "build": "tsc",
     "test": "jest --forceExit",
     "test:e2e": "start-server-and-test dev http-get://localhost:3000/expenditures/health 'jest --testMatch=\"**/*.e2e.test.ts\" --forceExit'",
-    "package": "esbuild handler.ts --bundle --platform=node --target=node20 --minify '--external:@aws-sdk/*' --outfile=dist/handler.js && cd dist && zip -q ../lambda.zip handler.js"
+    "package": "esbuild handler.ts --bundle --platform=node --target=node20 --minify '--external:@aws-sdk/*' --external:@sentry/aws-serverless --outfile=dist/handler.js && cd dist && zip -q ../lambda.zip handler.js"
   },
   "devDependencies": {
     "@branch/types": "file:../../../../shared/types",

--- a/apps/backend/lambdas/expenditures/services/expenditures.ts
+++ b/apps/backend/lambdas/expenditures/services/expenditures.ts
@@ -1,6 +1,7 @@
 import { Insertable, Updateable } from 'kysely';
 import { S3Client, PutObjectCommand, GetObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { reportError } from '@branch/lambda-http';
 import type { DB } from '@branch/types';
 import db from '../db';
 import type { ExpenditureStatus } from '../validation-utils';
@@ -44,6 +45,7 @@ export async function deleteReceiptObject(receiptUrl: string | null): Promise<bo
     return true;
   } catch (err) {
     console.error('Failed to delete receipt object', key, err);
+    reportError(err, { key });
     return false;
   }
 }

--- a/apps/backend/lambdas/projects/controllers/dashboard.ts
+++ b/apps/backend/lambdas/projects/controllers/dashboard.ts
@@ -1,5 +1,5 @@
 import { sql } from 'kysely';
-import { json, RouteHandler } from '@branch/lambda-http';
+import { json, RouteHandler, serverError } from '@branch/lambda-http';
 import db from '../db';
 import { APPROVED_EXPENDITURE_STATUS } from '../validation-utils';
 import { isProjectActive } from '../services/projects';
@@ -163,8 +163,7 @@ export const getDashboard: RouteHandler = async () => {
       expensesByMonth,
     });
   } catch (err) {
-    console.error('Dashboard query failed:', err);
-    return json(500, { message: 'Failed to load dashboard' });
+    return serverError(err, 'Failed to load dashboard');
   }
 };
 

--- a/apps/backend/lambdas/projects/controllers/expenditures.ts
+++ b/apps/backend/lambdas/projects/controllers/expenditures.ts
@@ -1,4 +1,4 @@
-import { json, RouteHandler } from '@branch/lambda-http';
+import { json, RouteHandler, serverError } from '@branch/lambda-http';
 import { can } from '@branch/rbac';
 import db from '../db';
 import { requireVisibleProject } from './project-guard';
@@ -34,9 +34,7 @@ export const getProjectExpenditures: RouteHandler = async (ctx) => {
       expenditures.map(({ admin_notes: _adminNotes, ...rest }) => rest),
     );
   } catch (err) {
-    console.error('Database error:', err);
-    return json(500, {
-      message: 'Failed to fetch expenditures',
+    return serverError(err, 'Failed to fetch expenditures', {
       error: err instanceof Error ? err.message : 'Unknown error',
     });
   }

--- a/apps/backend/lambdas/projects/controllers/projects.ts
+++ b/apps/backend/lambdas/projects/controllers/projects.ts
@@ -1,4 +1,4 @@
-import { json, parseBody, requirePermission, RouteHandler } from '@branch/lambda-http';
+import { json, parseBody, requirePermission, RouteHandler, serverError } from '@branch/lambda-http';
 import { projectScopeIds } from '@branch/rbac';
 import db from '../db';
 import { ProjectValidationUtils } from '../validation-utils';
@@ -140,8 +140,7 @@ export const updateProject: RouteHandler = async ({ event, params, auth }) => {
     if (!updatedProject) return json(404, { message: `Project not found for id: ${id}` });
     return json(200, updatedProject);
   } catch (e) {
-    console.error('Project update failed', e);
-    return json(500, { message: 'Failed to update project' });
+    return serverError(e, 'Failed to update project');
   }
 };
 
@@ -235,7 +234,6 @@ export const createProject: RouteHandler = async ({ event, auth }) => {
 
     return json(201, inserted);
   } catch (e) {
-    console.error('DB insert failed', e);
-    return json(500, { message: 'Failed to create project' });
+    return serverError(e, 'Failed to create project');
   }
 };

--- a/apps/backend/lambdas/projects/package.json
+++ b/apps/backend/lambdas/projects/package.json
@@ -7,7 +7,7 @@
     "dev": "ts-node --transpile-only dev-server.ts",
     "build": "tsc",
     "test": "start-server-and-test dev http-get://localhost:3000/projects/health jest",
-    "package": "esbuild handler.ts --bundle --platform=node --target=node20 --minify '--external:@aws-sdk/*' --outfile=dist/handler.js && cd dist && zip -q ../lambda.zip handler.js"
+    "package": "esbuild handler.ts --bundle --platform=node --target=node20 --minify '--external:@aws-sdk/*' --external:@sentry/aws-serverless --outfile=dist/handler.js && cd dist && zip -q ../lambda.zip handler.js"
   },
   "devDependencies": {
     "@branch/types": "file:../../../../shared/types",

--- a/apps/backend/lambdas/projects/services/projects.ts
+++ b/apps/backend/lambdas/projects/services/projects.ts
@@ -4,6 +4,7 @@ import {
   ListObjectsV2Command,
   DeleteObjectsCommand,
 } from '@aws-sdk/client-s3';
+import { reportError } from '@branch/lambda-http';
 import type { DB } from '@branch/types';
 import db from '../db';
 import { APPROVED_EXPENDITURE_STATUS, DEFAULT_PROJECT_ROLE, MemberAssignment } from '../validation-utils';
@@ -66,6 +67,7 @@ export async function deleteProjectObjects(projectId: number): Promise<number | 
     return counts[0] + counts[1];
   } catch (err) {
     console.error('Failed to delete objects for project', projectId, err);
+    reportError(err, { projectId });
     return null;
   }
 }

--- a/apps/backend/lambdas/reports/controllers/reports.ts
+++ b/apps/backend/lambdas/reports/controllers/reports.ts
@@ -1,6 +1,6 @@
 import { S3Client, PutObjectCommand, GetObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
-import { json, parseBody } from '@branch/lambda-http';
+import { json, parseBody, reportError, serverError } from '@branch/lambda-http';
 import type { RouteHandler } from '@branch/lambda-http';
 import db from '../db';
 import {
@@ -58,6 +58,7 @@ async function deleteReportObject(objectUrl: string | null): Promise<boolean> {
     return true;
   } catch (err) {
     console.error('Failed to delete report object', key, err);
+    reportError(err, { key });
     return false;
   }
 }
@@ -96,16 +97,14 @@ export const generateReport: RouteHandler = async ({ event }) => {
   try {
     fileBuffer = fileType === 'docx' ? await generateDocx(reportData) : await generatePdf(reportData);
   } catch (err) {
-    console.error('Report generation error:', err);
-    return json(500, { message: 'Failed to generate report' });
+    return serverError(err, 'Failed to generate report');
   }
 
   let objectUrl: string;
   try {
     objectUrl = await uploadToS3(fileBuffer, projectId, fileType);
   } catch (err) {
-    console.error('S3 upload error:', err);
-    return json(500, { message: 'Failed to upload report' });
+    return serverError(err, 'Failed to upload report');
   }
 
   const title = `${reportData.project.name} — ${new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}`;

--- a/apps/backend/lambdas/reports/package.json
+++ b/apps/backend/lambdas/reports/package.json
@@ -8,7 +8,7 @@
     "build": "tsc",
     "test": "jest --forceExit",
     "test:e2e": "start-server-and-test dev http-get://localhost:3000/reports/health 'jest --testMatch=\"**/*.e2e.test.ts\" --forceExit'",
-    "package": "esbuild handler.ts --bundle --platform=node --target=node20 --minify '--external:@aws-sdk/*' --outfile=dist/handler.js && mkdir -p dist/fonts/Roboto && cp node_modules/pdfmake/build/fonts/Roboto/*.ttf dist/fonts/Roboto/ && cd dist && zip -qr ../lambda.zip handler.js fonts"
+    "package": "esbuild handler.ts --bundle --platform=node --target=node20 --minify '--external:@aws-sdk/*' --external:@sentry/aws-serverless --outfile=dist/handler.js && mkdir -p dist/fonts/Roboto && cp node_modules/pdfmake/build/fonts/Roboto/*.ttf dist/fonts/Roboto/ && cd dist && zip -qr ../lambda.zip handler.js fonts"
   },
   "devDependencies": {
     "@branch/types": "file:../../../../shared/types",

--- a/apps/backend/lambdas/users/controllers/users.ts
+++ b/apps/backend/lambdas/users/controllers/users.ts
@@ -3,7 +3,7 @@ import {
   AdminCreateUserCommand,
   AdminDeleteUserCommand,
 } from '@aws-sdk/client-cognito-identity-provider';
-import { json, requirePermission, type RouteHandler } from '@branch/lambda-http';
+import { json, reportError, requirePermission, type RouteHandler } from '@branch/lambda-http';
 import db from '../db';
 import { UserValidationUtils } from '../validation-utils';
 import {
@@ -238,7 +238,10 @@ export const deleteUser: RouteHandler = async ({ params }) => {
       await cognitoClient.send(new AdminDeleteUserCommand({ UserPoolId: USER_POOL_ID, Username: user.email }));
     } catch (err: any) {
       if (err?.name !== 'UserNotFoundException') {
+        // The row is gone but the identity is not, so the email cannot be
+        // re-invited. The 200 says so; nothing else would.
         console.error('Cognito delete error:', err);
+        reportError(err, { email: user.email });
         cognitoDeleted = false;
       }
     }
@@ -307,6 +310,7 @@ export const createUser: RouteHandler = async ({ event }) => {
     if (err.name === 'UsernameExistsException') {
       return json(409, { message: 'User with this email already exists' });
     }
+    reportError(err);
     return json(500, { message: 'Failed to create user in authentication service' });
   }
 
@@ -326,8 +330,11 @@ export const createUser: RouteHandler = async ({ event }) => {
       }));
       console.log('Rolled back Cognito user after database failure');
     } catch (rollbackErr) {
+      // Orphaned Cognito user: no DB row, and the email is now unusable.
       console.error('Failed to rollback Cognito user:', rollbackErr);
+      reportError(rollbackErr, { email });
     }
+    reportError(err);
     return json(500, { message: 'Failed to create user' });
   }
 

--- a/apps/backend/lambdas/users/package.json
+++ b/apps/backend/lambdas/users/package.json
@@ -7,7 +7,7 @@
     "dev": "ts-node --transpile-only dev-server.ts",
     "build": "tsc",
     "test": "start-server-and-test dev http-get://localhost:3000/users/health jest",
-    "package": "esbuild handler.ts --bundle --platform=node --target=node20 --minify '--external:@aws-sdk/*' --outfile=dist/handler.js && cd dist && zip -q ../lambda.zip handler.js"
+    "package": "esbuild handler.ts --bundle --platform=node --target=node20 --minify '--external:@aws-sdk/*' --external:@sentry/aws-serverless --outfile=dist/handler.js && cd dist && zip -q ../lambda.zip handler.js"
   },
   "devDependencies": {
     "@branch/types": "file:../../../../shared/types",

--- a/apps/backend/lambdas/users/photos.ts
+++ b/apps/backend/lambdas/users/photos.ts
@@ -1,5 +1,6 @@
 import { S3Client, GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { reportError } from '@branch/lambda-http';
 
 const REGION = process.env.AWS_REGION ?? 'us-east-2';
 const BUCKET = process.env.REPORTS_BUCKET_NAME ?? '';
@@ -80,7 +81,10 @@ export async function resolveProfileImage(
     return await getSignedUrl(s3, new GetObjectCommand({ Bucket: BUCKET, Key: stored }), {
       expiresIn: 900,
     });
-  } catch {
+  } catch (err) {
+    // Degrading to a broken <img> is deliberate, but a bucket or IAM problem
+    // that breaks every avatar should still be visible somewhere.
+    reportError(err, { key: stored });
     return stored;
   }
 }

--- a/shared/lambda-http/README.md
+++ b/shared/lambda-http/README.md
@@ -51,6 +51,12 @@ the row is loaded.
   `resolveAuth`. A controller that runs has already cleared its route's gate.
 - OPTIONS preflight, `GET /<prefix>/health`, 404, and 500.
 - CORS headers on every response, via `json`.
+- **Sentry reporting for the 500 path.** The Sentry Lambda layer wraps the
+  handler and records *uncaught throws* only. Every lambda catches instead, so
+  API Gateway gets a JSON 500 rather than a 502 — which means an error that is
+  never handed to `reportError` is an error Sentry never sees. `dispatch`
+  reports what reaches its own catch; a controller that returns its own 500
+  must use `serverError`.
 
 ## Exports
 
@@ -62,6 +68,8 @@ the row is loaded.
 | `requirePermission(subject, action, resource?)` | 403 carrying the policy's own reason, or `undefined` when allowed. |
 | `createAuthResolver(authenticate, loadSubject)` | Bind a service's db-scoped auth into the `resolveAuth` dispatch expects. |
 | `matchPattern(pattern, path)` | Params on match, `null` otherwise. |
+| `serverError(err, message, body?)` | Log, report to Sentry, return a 500. Use instead of a bare `json(500, ...)` in a catch. |
+| `reportError(err, context?)` | Report to Sentry without producing a response. No-op when the layer is absent (local, tests). |
 
 ## Build
 

--- a/shared/lambda-http/src/dispatch.ts
+++ b/shared/lambda-http/src/dispatch.ts
@@ -3,6 +3,7 @@ import { authorize } from '@branch/rbac';
 import { json } from './response';
 import { matchPattern } from './match';
 import { ANONYMOUS_AUTH } from './authz';
+import { reportError } from './errors';
 import type { DispatchOptions, RequestAuth, Route } from './types';
 
 /**
@@ -22,15 +23,16 @@ export async function dispatch(
   event: any,
   { prefix, routes, resolveAuth }: DispatchOptions,
 ): Promise<APIGatewayProxyResult> {
-  try {
-    const rawPath: string = event.rawPath || event.path || '/';
-    let path = rawPath.replace(/\/+$/, '') || '/';
-    const method = (
-      event.requestContext?.http?.method ||
-      event.httpMethod ||
-      'GET'
-    ).toUpperCase();
+  // Hoisted out of the try so the catch can name the route that failed.
+  const rawPath: string = event?.rawPath || event?.path || '/';
+  let path = rawPath.replace(/\/+$/, '') || '/';
+  const method = (
+    event?.requestContext?.http?.method ||
+    event?.httpMethod ||
+    'GET'
+  ).toUpperCase();
 
+  try {
     // Canonicalize to `/<prefix>...` when the prefix was stripped (dev-server).
     const base = `/${prefix}`;
     if (path !== base && !path.startsWith(`${base}/`)) {
@@ -57,6 +59,9 @@ export async function dispatch(
     return json(404, { message: 'Not Found', path, method });
   } catch (err) {
     console.error('Lambda error:', err);
+    // The layer's wrapHandler only records throws, and catching here is what
+    // gets API Gateway a JSON 500 instead of a 502 -- so hand it over by hand.
+    reportError(err, { method, path });
     return json(500, { message: 'Internal Server Error' });
   }
 }
@@ -73,9 +78,11 @@ async function enforce(
   // A guarded route in a service that never wired up authentication is a
   // deployment bug, not an anonymous request. 500 rather than serving it.
   if (!resolveAuth) {
-    console.error(
+    const err = new Error(
       `Route ${route.method} ${route.pattern} is guarded but the service passed no resolveAuth`,
     );
+    console.error(err.message);
+    reportError(err);
     return { response: json(500, { message: 'Internal Server Error' }) };
   }
 

--- a/shared/lambda-http/src/errors.ts
+++ b/shared/lambda-http/src/errors.ts
@@ -1,0 +1,40 @@
+import type { APIGatewayProxyResult } from 'aws-lambda';
+import { json } from './response';
+
+/**
+ * Hand an error to Sentry.
+ *
+ * The Sentry SDK ships in the Lambda layer, never in these bundles, so the
+ * require resolves through NODE_PATH in prod and throws locally and in tests,
+ * where reporting is a no-op. The layer's `wrapHandler` only records uncaught
+ * throws, and every lambda returns a JSON 500 rather than throwing — so an
+ * error nobody passes through here is an error Sentry never sees.
+ */
+export function reportError(err: unknown, context?: Record<string, unknown>): void {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const Sentry = require('@sentry/aws-serverless') as {
+      captureException: (error: unknown, captureContext?: unknown) => void;
+    };
+    Sentry.captureException(err, context ? { extra: context } : undefined);
+  } catch {
+    // Layer absent, or the SDK itself failed. Reporting a failure must never
+    // replace the failure being reported.
+  }
+}
+
+/**
+ * Log, report, and return a 500. Use instead of a bare `json(500, ...)` in a
+ * catch — the status the caller sees is unchanged, but the error stops being
+ * invisible. `body` merges extra fields into the response for the handful of
+ * routes that already return more than a message.
+ */
+export function serverError(
+  err: unknown,
+  message: string,
+  body?: Record<string, unknown>,
+): APIGatewayProxyResult {
+  console.error(`${message}:`, err);
+  reportError(err);
+  return json(500, { message, ...body });
+}

--- a/shared/lambda-http/src/index.ts
+++ b/shared/lambda-http/src/index.ts
@@ -4,3 +4,4 @@ export { matchPattern } from './match';
 export { dispatch } from './dispatch';
 export { parseBody } from './body';
 export { requirePermission, createAuthResolver, ANONYMOUS_AUTH } from './authz';
+export { reportError, serverError } from './errors';

--- a/shared/lambda-http/test/dispatch.test.ts
+++ b/shared/lambda-http/test/dispatch.test.ts
@@ -3,6 +3,13 @@ import { dispatch } from '../src/dispatch';
 import { json } from '../src/response';
 import type { RequestAuth, Route } from '../src/types';
 
+jest.mock('@sentry/aws-serverless', () => ({ captureException: jest.fn() }), {
+  virtual: true,
+});
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Sentry = require('@sentry/aws-serverless') as { captureException: jest.Mock };
+
 const ok = (label: string): Route['handler'] => async (ctx) =>
   json(200, { label, params: ctx.params, path: ctx.path, subject: ctx.auth.subject });
 
@@ -111,7 +118,8 @@ describe('dispatch routing', () => {
     expect(body(res)).toMatchObject({ message: 'Not Found', path: '/projects/7/nope' });
   });
 
-  it('500s when a handler throws, without leaking the error', async () => {
+  it('500s when a handler throws, reports it, and does not leak the error', async () => {
+    Sentry.captureException.mockClear();
     const boom: Route[] = [
       {
         method: 'GET',
@@ -130,6 +138,14 @@ describe('dispatch routing', () => {
     });
     expect(res.statusCode).toBe(500);
     expect(res.body).not.toContain('secret detail');
+    // The Sentry layer only records uncaught throws; this one was caught.
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+    expect(Sentry.captureException.mock.calls[0][0]).toMatchObject({
+      message: 'secret detail',
+    });
+    expect(Sentry.captureException.mock.calls[0][1]).toEqual({
+      extra: { method: 'GET', path: '/projects' },
+    });
     spy.mockRestore();
   });
 });

--- a/shared/lambda-http/test/errors.test.ts
+++ b/shared/lambda-http/test/errors.test.ts
@@ -1,0 +1,67 @@
+import { reportError, serverError } from '../src/errors';
+
+jest.mock('@sentry/aws-serverless', () => ({ captureException: jest.fn() }), {
+  virtual: true,
+});
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Sentry = require('@sentry/aws-serverless') as { captureException: jest.Mock };
+
+describe('reportError', () => {
+  beforeEach(() => Sentry.captureException.mockClear());
+
+  it('hands the error to the layer SDK', () => {
+    const err = new Error('boom');
+    reportError(err);
+    expect(Sentry.captureException).toHaveBeenCalledWith(err, undefined);
+  });
+
+  it('attaches context as Sentry extras', () => {
+    const err = new Error('boom');
+    reportError(err, { method: 'GET', path: '/projects' });
+    expect(Sentry.captureException).toHaveBeenCalledWith(err, {
+      extra: { method: 'GET', path: '/projects' },
+    });
+  });
+
+  it('stays silent when the SDK itself throws', () => {
+    Sentry.captureException.mockImplementationOnce(() => {
+      throw new Error('sentry is down');
+    });
+    expect(() => reportError(new Error('boom'))).not.toThrow();
+  });
+});
+
+describe('serverError', () => {
+  let logged: jest.SpyInstance;
+
+  beforeEach(() => {
+    Sentry.captureException.mockClear();
+    logged = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+  afterEach(() => logged.mockRestore());
+
+  it('returns a 500 and reports the error without leaking it', () => {
+    const err = new Error('secret detail');
+    const res = serverError(err, 'Failed to create donor');
+
+    expect(res.statusCode).toBe(500);
+    expect(JSON.parse(res.body)).toEqual({ message: 'Failed to create donor' });
+    expect(res.body).not.toContain('secret detail');
+    expect(Sentry.captureException).toHaveBeenCalledWith(err, undefined);
+    expect(logged).toHaveBeenCalled();
+  });
+
+  it('merges extra body fields for routes that return more than a message', () => {
+    const res = serverError(new Error('boom'), 'MFA request failed', {
+      error: 'NotAuthorizedException',
+      code: 'NotAuthorizedException',
+    });
+
+    expect(JSON.parse(res.body)).toEqual({
+      message: 'MFA request failed',
+      error: 'NotAuthorizedException',
+      code: 'NotAuthorizedException',
+    });
+  });
+});


### PR DESCRIPTION
## Why

Sentry was wired correctly (layer `SentryNodeServerlessSDKv10:85`, `NODE_OPTIONS=--import @sentry/aws-serverless/awslambda-auto`, DSN, environment) but had never received an event, because the layer's `wrapHandler` records **uncaught throws only** and every lambda catches instead.

Catching is deliberate — it is what gets API Gateway a JSON 500 rather than a 502 — so the layer alone can never see a 500 this service produces. Confirmed against prod: a pre-migration deploy 500s `GET /prod/projects` with

```
error: relation "branch.expenditure_rollup" does not exist   (Postgres 42P01)
```

which appears in CloudWatch and nowhere else.

On top of that, 25 of the 41 production catch blocks return their own 500 and never reach `dispatch()`'s central catch at all.

## What

New in `@branch/lambda-http`:

| Export | Purpose |
| --- | --- |
| `reportError(err, context?)` | Report to Sentry, no response. No-op when the layer is absent (local, tests). |
| `serverError(err, message, body?)` | Log, report, return a 500. Drop-in for `console.error` + `json(500, …)`. |

Wired through:

- **`dispatch()`** reports what reaches its catch, with `method`/`path` as Sentry extras, and reports the guarded-route-without-`resolveAuth` misconfiguration.
- **The 25 controller-level 500s** now report. The Cognito and MFA error mappers report from their `default` arm only — the 4xx/429 arms are expected outcomes, not failures.
- **Best-effort catches that hide a real failure behind a success response** report without changing the response: Cognito rollback failures (which strand an orphaned identity whose email can never be reused), S3 receipt/report/project cleanup, and avatar presigning.

Left alone as genuine control flow: `parseBody`'s JSON parse → 400, JWT verify → 401, report-service URL parsing → null, the Cognito 4xx mappings, `donations.ts`'s rethrow (already reaches dispatch), and every `dev-server.ts` (not deployed).

**Status codes and response bodies are unchanged.**

## Packaging

The SDK still ships only in the layer — nothing is added to the bundles. `reportError` requires it at call time, resolving through `NODE_PATH` in prod. Each lambda's esbuild step now marks it `--external:@sentry/aws-serverless` so the require survives bundling instead of being resolved at build time. Verified in a minified bundle:

```js
function lc(t,e){try{require("@sentry/aws-serverless").captureException(t,e?{extra:e}:void 0)}catch{}}
```

## Testing

- `shared/lambda-http`: 39 tests pass across 4 suites, including a new `errors.test.ts` and a `dispatch` assertion that a thrown handler both 500s and reports.
- All six lambdas typecheck.
- `donors` bundles and zips clean.

## Note

Three 500 bodies echo the raw exception message to the client (`services/cognito.ts`, `mfa.ts`, `projects/controllers/expenditures.ts`). Behaviour is preserved here, but with reporting in place that leak is no longer buying anything and is worth removing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)