### PR TITLE
feat(projects): make admins implicit members of every project

### DIFF
--- a/apps/backend/db/seed.sql
+++ b/apps/backend/db/seed.sql
@@ -19,7 +19,10 @@
 INSERT INTO branch.users (name, email, is_admin) VALUES
 ('Ashley Duggan', 'ashley@branch.org', TRUE),
 ('Renee Reddy', 'renee@branch.org', TRUE),
-('Nour Shoreibah', 'nour@branch.org', TRUE);
+('Nour Shoreibah', 'nour@branch.org', TRUE),
+('Sam Okafor', 'sam@branch.org', FALSE),
+('Priya Raman', 'priya@branch.org', FALSE),
+('Diego Alvarez', 'diego@branch.org', FALSE);
 
 INSERT INTO branch.projects (name, description, total_budget, start_date, end_date, currency) VALUES
 ('Clinician Communication Study', 'Study of clinician-patient communication patterns', 500000, '2025-01-01', '2026-01-01', 'USD'),
@@ -38,9 +41,9 @@ INSERT INTO branch.project_donations (donor_id, project_id, amount, donated_at) 
 (3, 3, 90000, '2025-06-20');
 
 INSERT INTO branch.project_memberships (project_id, user_id, role, start_date, hours) VALUES
-(1, 1, 'Director', '2025-01-01', 100.00),
-(1, 2, 'Director', '2025-02-01', 80.00),
-(2, 3, 'Student', '2025-03-15', 60.00);
+(1, 4, 'Director', '2025-01-01', 100.00),
+(1, 5, 'Director', '2025-02-01', 80.00),
+(2, 6, 'Student', '2025-03-15', 60.00);
 
 -- Statuses are load-bearing too. Totals, charts and reports count 'approved'
 -- rows only, so the seed keeps one denied and one pending row: they give the

--- a/apps/backend/db/seed.sql
+++ b/apps/backend/db/seed.sql
@@ -50,12 +50,12 @@ INSERT INTO branch.project_memberships (project_id, user_id, role, start_date, h
 -- admin review queue something to show, and they keep the dashboard honest
 -- about what it excludes. 14000 of the 18000 below is approved spend.
 INSERT INTO branch.expenditures (project_id, entered_by, amount, category, description, status, spent_on) VALUES
-(1, 1, 5000, 'Travel', 'Domestic conference attendance', 'approved', '2025-02-10'),
-(1, 1, 4200, 'Travel Foreign', 'International collaborator meeting in London', 'approved', '2025-03-22'),
-(2, 2, 3000, 'General', 'Recording device supplies', 'approved', '2025-04-05'),
-(2, 2, 1500, 'Visitor / Honorarium', 'Guest lecturer honorarium', 'denied', '2025-05-18'),
-(3, 3, 2500, 'General', 'Educational materials', 'pending', '2025-07-12'),
-(3, 3, 1800, 'Travel', 'Local outreach travel', 'approved', '2025-08-03');
+(1, 4, 5000, 'Travel', 'Domestic conference attendance', 'approved', '2025-02-10'),
+(1, 4, 4200, 'Travel Foreign', 'International collaborator meeting in London', 'approved', '2025-03-22'),
+(2, 5, 3000, 'General', 'Recording device supplies', 'approved', '2025-04-05'),
+(2, 5, 1500, 'Visitor / Honorarium', 'Guest lecturer honorarium', 'denied', '2025-05-18'),
+(3, 6, 2500, 'General', 'Educational materials', 'pending', '2025-07-12'),
+(3, 6, 1800, 'Travel', 'Local outreach travel', 'approved', '2025-08-03');
 
 INSERT INTO branch.reports (project_id, title, object_url) VALUES
 (1, 'Clinician Communication Study Report', 'https://s3.amazonaws.com/branch-reports/clinician_communication_study_report.pdf'),

--- a/apps/backend/lambdas/auth/test/auth.e2e.test.ts
+++ b/apps/backend/lambdas/auth/test/auth.e2e.test.ts
@@ -131,7 +131,7 @@ test("seeded admins are pending invitations, not claimed accounts", async () => 
   const client = await pool.connect();
   try {
     const { rows } = await client.query(
-      'SELECT email, user_id, is_admin, cognito_sub FROM branch.users ORDER BY user_id'
+      'SELECT email, user_id, is_admin, cognito_sub FROM branch.users WHERE is_admin IS TRUE ORDER BY user_id'
     );
 
     expect(rows).toHaveLength(3);

--- a/apps/backend/lambdas/donors/test/donors.test.ts
+++ b/apps/backend/lambdas/donors/test/donors.test.ts
@@ -55,20 +55,20 @@ const authenticatedUser = {
   isAuthenticated: true,
   user: {
     cognitoSub: 'staff-sub',
-    userId: 1,
-    email: 'person@branch.org',
+    userId: 4,
+    email: 'sam@branch.org',
     isAdmin: false,
   },
 }
 
-// Seed user 3 is a Student on project 2 only -- no memberships on projects 1 or
+// Seed user 6 is a Student on project 2 only -- no memberships on projects 1 or
 // 3, and not a director anywhere.
 const studentUser = {
   isAuthenticated: true,
   user: {
     cognitoSub: 'student-sub',
-    userId: 3,
-    email: 'nour@branch.org',
+    userId: 6,
+    email: 'diego@branch.org',
     isAdmin: false,
   },
 }

--- a/apps/backend/lambdas/expenditures/test/expenditures.e2e.test.ts
+++ b/apps/backend/lambdas/expenditures/test/expenditures.e2e.test.ts
@@ -93,35 +93,35 @@ const adminUser = {
   },
 };
 
-// Non-admin user 1: has Director role on project 1
+// Non-admin user 4: has Director role on project 1
 const directorUser = {
   isAuthenticated: true as const,
   user: {
     cognitoSub: 'director-sub',
-    userId: 1,
-    email: 'ashley@branch.org',
+    userId: 4,
+    email: 'sam@branch.org',
     isAdmin: false,
   },
 };
 
-// Non-admin user 2: also has Director role on project 1
+// Non-admin user 5: also has Director role on project 1
 const secondDirectorUser = {
   isAuthenticated: true as const,
   user: {
     cognitoSub: 'second-director-sub',
-    userId: 2,
-    email: 'renee@branch.org',
+    userId: 5,
+    email: 'priya@branch.org',
     isAdmin: false,
   },
 };
 
-// Non-admin user 3: has Student role on project 2, no role on project 1
+// Non-admin user 6: has Student role on project 2, no role on project 1
 const studentUser = {
   isAuthenticated: true as const,
   user: {
     cognitoSub: 'student-sub',
-    userId: 3,
-    email: 'nour@branch.org',
+    userId: 6,
+    email: 'diego@branch.org',
     isAdmin: false,
   },
 };
@@ -224,10 +224,10 @@ describe('Expenditures integration tests', () => {
     test('201: a second Director on the same project can create expenditure', async () => {
       mockAuthenticateRequest.mockResolvedValue(secondDirectorUser);
 
-      // User 2 is also a Director on project 1
+      // User 5 is also a Director on project 1
       const res = await handler(postEvent({ projectID: 1, amount: 750 }));
       expect(res.statusCode).toBe(201);
-      expect(JSON.parse(res.body).body.enteredBy).toBe(2);
+      expect(JSON.parse(res.body).body.enteredBy).toBe(5);
     });
 
     // Filing an expense is open to any member of the project now -- it used to
@@ -577,7 +577,7 @@ describe('Expenditures integration tests', () => {
 
     test('403: a member of the project who did not submit it cannot delete', async () => {
       mockAuthenticateRequest.mockResolvedValue(studentUser);
-      const id = await firstExpenditureId(2); // entered_by 2; studentUser is user 3
+      const id = await firstExpenditureId(2); // entered_by 5; studentUser is user 6
 
       const res = await handler(idRequestEvent('DELETE', id));
       expect(res.statusCode).toBe(403);
@@ -588,7 +588,7 @@ describe('Expenditures integration tests', () => {
     // point: directing the project does not thaw them, and neither does having
     // submitted them.
     test('403: an approved expenditure is frozen even for its submitter', async () => {
-      mockAuthenticateRequest.mockResolvedValue(directorUser); // user 1, submitted it
+      mockAuthenticateRequest.mockResolvedValue(directorUser); // user 4, submitted it
       const id = await firstExpenditureId(1);
 
       const res = await handler(idRequestEvent('DELETE', id));
@@ -598,15 +598,15 @@ describe('Expenditures integration tests', () => {
     });
 
     test('403: a Director on the project cannot delete an expenditure they did not submit', async () => {
-      mockAuthenticateRequest.mockResolvedValue(secondDirectorUser); // user 2, on project 1
-      const id = await firstExpenditureId(1); // entered_by 1
+      mockAuthenticateRequest.mockResolvedValue(secondDirectorUser); // user 5, on project 1
+      const id = await firstExpenditureId(1); // entered_by 4
 
       const res = await handler(idRequestEvent('DELETE', id));
       expect(res.statusCode).toBe(403);
       expect(await expenditureExists(id)).toBe(true);
     });
 
-    // Seeded expenditure 5 is project 3, entered_by 3, still pending. User 3
+    // Seeded expenditure 5 is project 3, entered_by 6, still pending. User 6
     // has no membership there, so this also covers the author keeping access
     // to what they filed after leaving a project.
     test('200: the submitter can delete their own pending expenditure', async () => {

--- a/apps/backend/lambdas/projects/controllers/dashboard.ts
+++ b/apps/backend/lambdas/projects/controllers/dashboard.ts
@@ -2,7 +2,7 @@ import { sql } from 'kysely';
 import { json, RouteHandler } from '@branch/lambda-http';
 import db from '../db';
 import { APPROVED_EXPENDITURE_STATUS } from '../validation-utils';
-import { isProjectActive } from '../services/projects';
+import { isProjectActive, listRoster, loadAdminHeadcount } from '../services/projects';
 import { requireVisibleProject } from './project-guard';
 
 // Authentication and each route's declared permission are enforced by dispatch
@@ -117,6 +117,10 @@ export const getDashboard: RouteHandler = async () => {
     const activeSpent = Number(activeSpentRow?.total ?? 0);
     const averageSpendPerProject = totalProjects > 0 ? activeSpent / totalProjects : 0;
 
+    const { admins, storedAdmins } = await loadAdminHeadcount(
+      projectRows.map((p) => p.project_id),
+    );
+
     const projects = projectRows.map((p) => {
       const budget = p.total_budget !== null ? Number(p.total_budget) : null;
       const spent = Number(p.spent ?? 0);
@@ -127,7 +131,8 @@ export const getDashboard: RouteHandler = async () => {
         total_budget: budget,
         currency: p.currency,
         spent,
-        staff_count: Number(p.staff_count ?? 0),
+        staff_count:
+          Number(p.staff_count ?? 0) - (storedAdmins.get(p.project_id) ?? 0) + admins,
         spent_percentage: Number(spentPercentage.toFixed(2)),
       };
     });
@@ -180,13 +185,7 @@ export const getOverview: RouteHandler = async (ctx) => {
   // once and the 404 is settled from the result rather than ahead of them.
   const [project, members, expenditures, donationRow] = await Promise.all([
     db.selectFrom('branch.projects').where('project_id', '=', id).selectAll().executeTakeFirst(),
-    db
-      .selectFrom('branch.project_memberships as pm')
-      .innerJoin('branch.users as u', 'u.user_id', 'pm.user_id')
-      .select(['u.user_id', 'u.name', 'u.email', 'u.profile_image', 'pm.role'])
-      .where('pm.project_id', '=', id)
-      .orderBy('u.name', 'asc')
-      .execute(),
+    listRoster(id),
     db
       .selectFrom('branch.expenditures')
       .where('project_id', '=', id)

--- a/apps/backend/lambdas/projects/controllers/members.ts
+++ b/apps/backend/lambdas/projects/controllers/members.ts
@@ -1,5 +1,6 @@
 import { json, RouteHandler } from '@branch/lambda-http';
 import db from '../db';
+import { listRoster } from '../services/projects';
 import { requireVisibleProject } from './project-guard';
 
 // Authentication and each route's declared permission are enforced by dispatch
@@ -10,12 +11,7 @@ export const getMembers: RouteHandler = async (ctx) => {
   const { projectId, response } = requireVisibleProject(ctx);
   if (response) return response;
 
-  const users = await db
-    .selectFrom('branch.project_memberships as pm')
-    .innerJoin('branch.users as u', 'u.user_id', 'pm.user_id')
-    .select(['u.user_id', 'u.name', 'u.email', 'pm.role'])
-    .where('pm.project_id', '=', projectId)
-    .execute();
+  const users = await listRoster(projectId);
 
   return json(200, {
     ok: true,
@@ -33,6 +29,7 @@ export const getAssignableStaff: RouteHandler = async () => {
   const staff = await db
     .selectFrom('branch.users')
     .select(['user_id', 'name', 'email', 'profile_image'])
+    .where('is_admin', 'is not', true)
     .orderBy('name', 'asc')
     .execute();
   return json(200, { staff });

--- a/apps/backend/lambdas/projects/controllers/projects.ts
+++ b/apps/backend/lambdas/projects/controllers/projects.ts
@@ -5,9 +5,12 @@ import db from '../db';
 import { ProjectValidationUtils } from '../validation-utils';
 import { requireVisibleProject } from './project-guard';
 import {
+  ADMIN_ASSIGNMENT_MESSAGE,
   deleteProjectObjects,
+  findAdminUserIds,
   findUnknownUserIds,
   isProjectActive,
+  loadAdminHeadcount,
   loadProjectAggregates,
   syncMemberships,
   toIsoDate,
@@ -33,14 +36,19 @@ export const listProjects: RouteHandler = async ({ auth }) => {
   // The list cards render "spent / budget", a member count and an
   // active-vs-archived split. Serving those aggregates here keeps the page
   // to one request instead of three per project.
-  const { spent, members } = await loadProjectAggregates(projects.map((p) => p.project_id));
+  const projectIds = projects.map((p) => p.project_id);
+  const [{ spent, members }, { admins, storedAdmins }] = await Promise.all([
+    loadProjectAggregates(projectIds),
+    loadAdminHeadcount(projectIds),
+  ]);
 
   return json(
     200,
     projects.map((p) => ({
       ...p,
       total_spent: spent.get(p.project_id) ?? 0,
-      member_count: members.get(p.project_id) ?? 0,
+      member_count:
+        (members.get(p.project_id) ?? 0) - (storedAdmins.get(p.project_id) ?? 0) + admins,
       is_active: isProjectActive(p.end_date),
     })),
   );
@@ -115,6 +123,10 @@ export const updateProject: RouteHandler = async ({ event, params, auth }) => {
     const unknownIds = await findUnknownUserIds(members);
     if (unknownIds.length > 0) {
       return json(400, { message: `Unknown user ids: ${unknownIds.join(', ')}` });
+    }
+    const adminIds = await findAdminUserIds(members);
+    if (adminIds.length > 0) {
+      return json(400, { message: ADMIN_ASSIGNMENT_MESSAGE });
     }
   }
 
@@ -219,6 +231,10 @@ export const createProject: RouteHandler = async ({ event, auth }) => {
   const unknownIds = await findUnknownUserIds(members);
   if (unknownIds.length > 0) {
     return json(400, { message: `Unknown user ids: ${unknownIds.join(', ')}` });
+  }
+  const adminIds = await findAdminUserIds(members);
+  if (adminIds.length > 0) {
+    return json(400, { message: ADMIN_ASSIGNMENT_MESSAGE });
   }
 
   try {

--- a/apps/backend/lambdas/projects/services/projects.ts
+++ b/apps/backend/lambdas/projects/services/projects.ts
@@ -6,6 +6,7 @@ import {
 } from '@aws-sdk/client-s3';
 import type { DB } from '@branch/types';
 import db from '../db';
+import { ADMIN_MEMBER_ROLE, type MemberDisplayRole } from '@branch/rbac';
 import { APPROVED_EXPENDITURE_STATUS, DEFAULT_PROJECT_ROLE, MemberAssignment } from '../validation-utils';
 
 const s3 = new S3Client({ region: process.env.AWS_REGION ?? 'us-east-2' });
@@ -139,6 +140,69 @@ export function isProjectActive(endDate: unknown, today = new Date()): boolean {
   return iso >= today.toISOString().slice(0, 10);
 }
 
+export interface RosterMember {
+  user_id: number;
+  name: string;
+  email: string;
+  profile_image: string | null;
+  role: MemberDisplayRole;
+}
+
+export async function listRoster(projectId: number): Promise<RosterMember[]> {
+  const [admins, stored] = await Promise.all([
+    db
+      .selectFrom('branch.users')
+      .select(['user_id', 'name', 'email', 'profile_image'])
+      .where('is_admin', 'is', true)
+      .orderBy('name', 'asc')
+      .execute(),
+    db
+      .selectFrom('branch.project_memberships as pm')
+      .innerJoin('branch.users as u', 'u.user_id', 'pm.user_id')
+      .select(['u.user_id', 'u.name', 'u.email', 'u.profile_image', 'pm.role'])
+      .where('pm.project_id', '=', projectId)
+      .orderBy('u.name', 'asc')
+      .execute(),
+  ]);
+
+  const adminIds = new Set(admins.map((a) => a.user_id));
+
+  return [
+    ...admins.map((a) => ({ ...a, role: ADMIN_MEMBER_ROLE as MemberDisplayRole })),
+    ...stored
+      .filter((m) => !adminIds.has(m.user_id))
+      .map((m) => ({ ...m, role: m.role as MemberDisplayRole })),
+  ];
+}
+
+export async function loadAdminHeadcount(projectIds: number[]): Promise<{
+  admins: number;
+  storedAdmins: Map<number, number>;
+}> {
+  const [totalRow, storedRows] = await Promise.all([
+    db
+      .selectFrom('branch.users')
+      .select((eb) => eb.fn.countAll<string>().as('count'))
+      .where('is_admin', 'is', true)
+      .executeTakeFirst(),
+    projectIds.length === 0
+      ? Promise.resolve([])
+      : db
+          .selectFrom('branch.project_memberships as pm')
+          .innerJoin('branch.users as u', 'u.user_id', 'pm.user_id')
+          .select(['pm.project_id', (eb) => eb.fn.countAll<string>().as('count')])
+          .where('u.is_admin', 'is', true)
+          .where('pm.project_id', 'in', projectIds)
+          .groupBy('pm.project_id')
+          .execute(),
+  ]);
+
+  return {
+    admins: Number(totalRow?.count ?? 0),
+    storedAdmins: indexByProject(storedRows, (r) => Number(r.count ?? 0)),
+  };
+}
+
 /**
  * Replaces a project's roster with `members` inside the caller's transaction.
  *
@@ -180,6 +244,24 @@ export async function syncMemberships(
       })),
     )
     .execute();
+}
+
+export const ADMIN_ASSIGNMENT_MESSAGE =
+  'Admins are on every project and cannot be assigned to one.';
+
+export async function findAdminUserIds(members: MemberAssignment[]): Promise<number[]> {
+  if (members.length === 0) return [];
+  const admins = await db
+    .selectFrom('branch.users')
+    .select('user_id')
+    .where('is_admin', 'is', true)
+    .where(
+      'user_id',
+      'in',
+      members.map((m) => m.user_id),
+    )
+    .execute();
+  return admins.map((row) => row.user_id);
 }
 
 /** Rejects member ids that are not real users, so FK errors never reach the client as a 500. */

--- a/apps/backend/lambdas/projects/test/dashboard.unit.test.ts
+++ b/apps/backend/lambdas/projects/test/dashboard.unit.test.ts
@@ -123,6 +123,8 @@ describe('GET /dashboard unit tests', () => {
         { month: '2025-02', category: 'Travel', total: '5000.00' },
         { month: '2025-03', category: 'Travel Foreign', total: '4200.00' },
       ]));
+      mockDb.selectFrom.mockReturnValueOnce(chain({ count: '1' }));
+      mockDb.selectFrom.mockReturnValueOnce(chain([]));
     });
 
     test('200: summary aggregates returned values', async () => {
@@ -154,12 +156,12 @@ describe('GET /dashboard unit tests', () => {
         name: 'P1',
         total_budget: 500000,
         spent: 9200,
-        staff_count: 2,
+        staff_count: 3,
       });
       expect(body.projects[0].spent_percentage).toBeCloseTo(1.84, 2);
 
-      // project with no membership row -> staff_count 0
-      expect(body.projects[2].staff_count).toBe(0);
+      // project with no membership row -> just the implicit admin
+      expect(body.projects[2].staff_count).toBe(1);
       // project with null budget -> 0%
       expect(body.projects[2].total_budget).toBeNull();
       expect(body.projects[2].spent_percentage).toBe(0);
@@ -190,6 +192,8 @@ describe('GET /dashboard unit tests', () => {
       mockDb.selectFrom.mockReturnValueOnce(chain({ total: null }));
       mockDb.selectFrom.mockReturnValueOnce(chain([]));
       mockDb.selectFrom.mockReturnValueOnce(chain([]));
+      mockDb.selectFrom.mockReturnValueOnce(chain({ count: '0' }));
+      mockDb.selectFrom.mockReturnValueOnce(chain([]));
 
       const res = await handler(getEvent());
       expect(res.statusCode).toBe(200);
@@ -211,6 +215,8 @@ describe('GET /dashboard unit tests', () => {
       mockDb.selectFrom.mockReturnValueOnce(chain([]));
       mockDb.selectFrom.mockReturnValueOnce(chain([]));
 
+      mockDb.selectFrom.mockReturnValueOnce(chain({ count: '0' }));
+
       const res = await handler(getEvent());
       const body = JSON.parse(res.body);
       expect(body.summary.topExpenseCategory.percentage).toBe(0);
@@ -228,6 +234,8 @@ describe('GET /dashboard unit tests', () => {
       mockDb.selectFrom.mockReturnValueOnce(chain([]));
       mockDb.selectFrom.mockReturnValueOnce(chain([]));
 
+      mockDb.selectFrom.mockReturnValueOnce(chain({ count: '0' }));
+
       const body = JSON.parse((await handler(getEvent())).body);
       // 12000/4, not 18000/4: the 6000 belonging to projects that have already
       // ended is out of the numerator, matching the denominator.
@@ -244,6 +252,8 @@ describe('GET /dashboard unit tests', () => {
       mockDb.selectFrom.mockReturnValueOnce(chain({ total: null }));
       mockDb.selectFrom.mockReturnValueOnce(chain([]));
       mockDb.selectFrom.mockReturnValueOnce(chain([]));
+
+      mockDb.selectFrom.mockReturnValueOnce(chain({ count: '0' }));
 
       const body = JSON.parse((await handler(getEvent())).body);
       expect(body.summary.averageSpendPerProject).toBe(0);

--- a/apps/backend/lambdas/projects/test/project-page.unit.test.ts
+++ b/apps/backend/lambdas/projects/test/project-page.unit.test.ts
@@ -94,6 +94,9 @@ afterAll(async () => {
   await db.destroy();
 });
 
+const stored = (members: Array<{ user_id: number; role: string }>) =>
+  members.filter((m) => m.role !== 'Admin');
+
 // ── Routing ──────────────────────────────────────────────────────────────────
 
 test('/projects/assignable-staff is not parsed as a project id', async () => {
@@ -128,7 +131,7 @@ test('list includes spend, member count and the active flag', async () => {
       total_budget: 1000,
       start_date: '2020-01-01',
       end_date: '2020-06-01',
-      members: [1, 2],
+      members: [4, 5],
     }),
   );
 
@@ -136,14 +139,14 @@ test('list includes spend, member count and the active flag', async () => {
   expect(res.statusCode).toBe(200);
   const created = parse(res).find((p: { name: string }) => p.name === 'Aggregated');
 
-  expect(created.member_count).toBe(2);
+  expect(created.member_count).toBe(5);
   expect(created.total_spent).toBe(0);
   // End date is in the past, so the list page files it under Archived.
   expect(created.is_active).toBe(false);
 });
 
 test('a project with no end date is always active', async () => {
-  await handler(event('/', 'POST', { name: 'Ongoing', total_budget: 10, members: [1] }));
+  await handler(event('/', 'POST', { name: 'Ongoing', total_budget: 10, members: [4] }));
   const res = await handler(event('/', 'GET'));
   const created = parse(res).find((p: { name: string }) => p.name === 'Ongoing');
   expect(created.is_active).toBe(true);
@@ -154,7 +157,7 @@ test('a project with no end date is always active', async () => {
 test('overview returns the project, stats, members and expenditures together', async () => {
   const created = parse(
     await handler(
-      event('/', 'POST', { name: 'Overview', total_budget: 1000, members: [1, 2] }),
+      event('/', 'POST', { name: 'Overview', total_budget: 1000, members: [4, 5] }),
     ),
   );
 
@@ -163,7 +166,7 @@ test('overview returns the project, stats, members and expenditures together', a
 
   const body = parse(res);
   expect(body.project.name).toBe('Overview');
-  expect(body.members).toHaveLength(2);
+  expect(stored(body.members)).toHaveLength(2);
   expect(body.stats.totalBudget).toBe(1000);
   expect(body.stats.totalSpent).toBe(0);
   expect(body.stats.totalRemaining).toBe(1000);
@@ -174,7 +177,7 @@ test('overview returns the project, stats, members and expenditures together', a
 });
 
 test('overview reports 0% rather than NaN when no budget is set', async () => {
-  const created = parse(await handler(event('/', 'POST', { name: 'No budget', members: [1] })));
+  const created = parse(await handler(event('/', 'POST', { name: 'No budget', members: [4] })));
   const body = parse(await handler(event(`/${created.project_id}/overview`, 'GET')));
   expect(body.stats.spentPercentage).toBe(0);
 });
@@ -188,43 +191,43 @@ test('overview 404s for a project that does not exist', async () => {
 
 test('POST assigns the given staff', async () => {
   const created = parse(
-    await handler(event('/', 'POST', { name: 'Staffed', total_budget: 5, members: [1, 3] })),
+    await handler(event('/', 'POST', { name: 'Staffed', total_budget: 5, members: [4, 6] })),
   );
   const body = parse(await handler(event(`/${created.project_id}/overview`, 'GET')));
-  expect(body.members.map((m: { user_id: number }) => m.user_id).sort()).toEqual([1, 3]);
+  expect(stored(body.members).map((m) => m.user_id).sort()).toEqual([4, 6]);
 });
 
 test('PUT replaces the roster rather than appending to it', async () => {
   const created = parse(
-    await handler(event('/', 'POST', { name: 'Rotating', total_budget: 5, members: [1, 2] })),
+    await handler(event('/', 'POST', { name: 'Rotating', total_budget: 5, members: [4, 5] })),
   );
 
-  const res = await handler(event(`/${created.project_id}`, 'PUT', { members: [3] }));
+  const res = await handler(event(`/${created.project_id}`, 'PUT', { members: [6] }));
   expect(res.statusCode).toBe(200);
 
   const body = parse(await handler(event(`/${created.project_id}/overview`, 'GET')));
-  expect(body.members.map((m: { user_id: number }) => m.user_id)).toEqual([3]);
+  expect(stored(body.members).map((m) => m.user_id)).toEqual([6]);
 });
 
 test('PUT without a members key leaves the roster alone', async () => {
   const created = parse(
-    await handler(event('/', 'POST', { name: 'Untouched', total_budget: 5, members: [1, 2] })),
+    await handler(event('/', 'POST', { name: 'Untouched', total_budget: 5, members: [4, 5] })),
   );
 
   await handler(event(`/${created.project_id}`, 'PUT', { name: 'Renamed' }));
 
   const body = parse(await handler(event(`/${created.project_id}/overview`, 'GET')));
   expect(body.project.name).toBe('Renamed');
-  expect(body.members).toHaveLength(2);
+  expect(stored(body.members)).toHaveLength(2);
 });
 
 test('PUT with an empty members array clears the roster', async () => {
   const created = parse(
-    await handler(event('/', 'POST', { name: 'Emptied', total_budget: 5, members: [1] })),
+    await handler(event('/', 'POST', { name: 'Emptied', total_budget: 5, members: [4] })),
   );
   await handler(event(`/${created.project_id}`, 'PUT', { members: [] }));
   const body = parse(await handler(event(`/${created.project_id}/overview`, 'GET')));
-  expect(body.members).toHaveLength(0);
+  expect(stored(body.members)).toHaveLength(0);
 });
 
 test('400 for a member id that is not a real user', async () => {
@@ -244,10 +247,10 @@ test('400 for a member entry that is not a positive integer id', async () => {
 
 test('a duplicated member id is de-duplicated instead of failing the write', async () => {
   const created = parse(
-    await handler(event('/', 'POST', { name: 'Deduped', total_budget: 5, members: [1, 1] })),
+    await handler(event('/', 'POST', { name: 'Deduped', total_budget: 5, members: [4, 4] })),
   );
   const body = parse(await handler(event(`/${created.project_id}/overview`, 'GET')));
-  expect(body.members).toHaveLength(1);
+  expect(stored(body.members)).toHaveLength(1);
 });
 
 // ── Date range ───────────────────────────────────────────────────────────────
@@ -259,7 +262,7 @@ test('400 when the end date precedes the start date on create', async () => {
       total_budget: 5,
       start_date: '2026-05-01',
       end_date: '2026-01-01',
-      members: [1],
+      members: [4],
     }),
   );
   expect(res.statusCode).toBe(400);
@@ -274,7 +277,7 @@ test('400 when an update moves the start date past the stored end date', async (
         total_budget: 5,
         start_date: '2026-01-01',
         end_date: '2026-02-01',
-        members: [1],
+        members: [4],
       }),
     ),
   );
@@ -292,7 +295,7 @@ test('clearing the end date in the same request that moves the start date is all
         total_budget: 5,
         start_date: '2026-01-01',
         end_date: '2026-02-01',
-        members: [1],
+        members: [4],
       }),
     ),
   );

--- a/apps/backend/lambdas/projects/test/projects.e2e.test.ts
+++ b/apps/backend/lambdas/projects/test/projects.e2e.test.ts
@@ -63,8 +63,8 @@ beforeAll(async () => {
 });
 
 
-// Non-admin users inserted by the Authorization block after each reseed.
-// The seed creates users 1-3, so these deterministically become 4 and 5.
+// Non-admin users inserted by the Authorization block after each reseed, which
+// fills in their ids -- the seed's own user count is not fixed.
 const nonMemberUser = {
   isAuthenticated: true as const,
   user: { cognitoSub: 'nonmember-sub', userId: 4, email: 'nonmember@branch.org', isAdmin: false },
@@ -133,11 +133,16 @@ describe('Authorization', () => {
   beforeEach(async () => {
     const client = await pool.connect();
     try {
-      await client.query(
+      const { rows } = await client.query(
         `INSERT INTO branch.users (name, email, is_admin) VALUES
            ('Non Member', 'nonmember@branch.org', FALSE),
-           ('Director Member', 'directormember@branch.org', FALSE)`,
+           ('Director Member', 'directormember@branch.org', FALSE)
+         RETURNING user_id, email`,
       );
+      const idFor = (email: string) =>
+        rows.find((r: { email: string }) => r.email === email).user_id;
+      nonMemberUser.user.userId = idFor('nonmember@branch.org');
+      directorMemberUser.user.userId = idFor('directormember@branch.org');
       await client.query(
         `INSERT INTO branch.project_memberships (project_id, user_id, role, start_date, hours)
          SELECT 1, user_id, 'Director', '2025-01-01', 10 FROM branch.users WHERE email = 'directormember@branch.org'`,
@@ -469,7 +474,7 @@ describe('GET /dashboard (e2e)', () => {
     expect(p1.name).toContain('Clinician Communication Study');
     expect(p1.total_budget).toBe(500000);
     expect(p1.spent).toBe(9200);
-    expect(p1.staff_count).toBe(2);
+    expect(p1.staff_count).toBe(5);
     expect(p1.spent_percentage).toBeCloseTo(1.84, 2);
   });
 
@@ -479,7 +484,7 @@ describe('GET /dashboard (e2e)', () => {
     const projB = body.projects.find((p: any) => p.name === 'Proj B');
     expect(projB).toBeDefined();
     expect(projB.spent).toBe(0);
-    expect(projB.staff_count).toBe(0);
+    expect(projB.staff_count).toBe(3);
   });
 
   test('expensesByMonth rows are chronological with numeric amounts 🌞', async () => {

--- a/apps/backend/lambdas/projects/test/rollups.e2e.test.ts
+++ b/apps/backend/lambdas/projects/test/rollups.e2e.test.ts
@@ -351,8 +351,10 @@ describe('project_rollup trigger', () => {
     `);
     await auditRollups(client);
 
-    const projects = await get('/');
-    expect(projects.find((p: any) => p.project_id === 1).member_count).toBe(2);
+    const { rows } = await client.query(
+      'SELECT member_count FROM branch.project_rollup WHERE project_id = 1',
+    );
+    expect(rows[0].member_count).toBe(2);
   });
 
   test('moving a donation between projects debits one and credits the other', async () => {
@@ -376,9 +378,12 @@ describe('project_rollup trigger', () => {
     `);
     await auditRollups(client);
 
-    const projects = await get('/');
-    expect(projects.find((p: any) => p.project_id === 1).member_count).toBe(0);
-    expect(projects.find((p: any) => p.project_id === 2).member_count).toBe(1);
+    const { rows } = await client.query(
+      'SELECT project_id, member_count FROM branch.project_rollup WHERE project_id IN (1, 2)',
+    );
+    const byProject = new Map(rows.map((r: any) => [r.project_id, r.member_count]));
+    expect(byProject.get(1)).toBe(0);
+    expect(byProject.get(2)).toBe(1);
   });
 
   test('TRUNCATE of donations, memberships and reports zeroes their counters', async () => {

--- a/apps/backend/lambdas/users/test/users.test.ts
+++ b/apps/backend/lambdas/users/test/users.test.ts
@@ -231,7 +231,7 @@ test("patch user 404 test 🌞", async () => {
   // 400 under the name of a 404.
   const event = createEvent({
     method: 'PATCH',
-    path: '/4',
+    path: '/99999',
     body: {
       name: "John Doe"
     },
@@ -256,7 +256,7 @@ test("get users test", async () => {
   console.log(body);
   expect(body.users).toBeDefined();
   expect(Array.isArray(body.users)).toBe(true);
-  expect(body.users.length).toBe(3);
+  expect(body.users.length).toBe(6);
 
   const firstUser = body.users[0];
   expect(firstUser.email).toBe("ashley@branch.org");
@@ -295,8 +295,8 @@ test("get users with correct pagnation", async () => {
   expect(body.pagination).toBeDefined();
   expect(body.pagination.page).toBe(1);
   expect(body.pagination.limit).toBe(1);
-  expect(body.pagination.totalUsers).toBe(3);
-  expect(body.pagination.totalPages).toBe(3);
+  expect(body.pagination.totalUsers).toBe(6);
+  expect(body.pagination.totalPages).toBe(6);
 
   expect(body.users).toBeDefined();
   expect(body.users.length).toBe(1);
@@ -327,7 +327,7 @@ test("get users with only page", async () => {
   expect(body.pagination).toBeUndefined();
 
   expect(body.users).toBeDefined();
-  expect(body.users.length).toBe(3);
+  expect(body.users.length).toBe(6);
 });
 
 
@@ -349,7 +349,7 @@ test("get users with only limit", async () => {
   expect(body.pagination).toBeUndefined();
 
   expect(body.users).toBeDefined();
-  expect(body.users.length).toBe(3);
+  expect(body.users.length).toBe(6);
 });
 
 test("get users with limit above total user", async () => {
@@ -369,11 +369,11 @@ test("get users with limit above total user", async () => {
   expect(body.pagination).toBeDefined();
   expect(body.pagination.page).toBe(1);
   expect(body.pagination.limit).toBe(100);
-  expect(body.pagination.totalUsers).toBe(3);
+  expect(body.pagination.totalUsers).toBe(6);
   expect(body.pagination.totalPages).toBe(1);
 
   expect(body.users).toBeDefined();
-  expect(body.users.length).toBe(3);
+  expect(body.users.length).toBe(6);
 });
 
 // Wrong path

--- a/apps/frontend/src/app/components/ProjectFormModal.tsx
+++ b/apps/frontend/src/app/components/ProjectFormModal.tsx
@@ -7,6 +7,7 @@ import TextInputField from './TextInputField';
 import DatePickerField from './DatePickerField';
 import StaffPicker from './StaffPicker';
 import { useApi } from '@/hooks/useApi';
+import { ADMIN_MEMBER_ROLE } from '@/types';
 import type {
   AssignableStaff,
   Member,
@@ -141,10 +142,11 @@ export default function ProjectFormModal({
             startDate: project.start_date?.slice(0, 10) ?? '',
             endDate: project.end_date?.slice(0, 10) ?? '',
             inProgress: !project.end_date,
-            members: members.map((m) => ({
-              user_id: m.user_id,
-              role: m.role,
-            })),
+            members: members.flatMap((m) =>
+              m.role === ADMIN_MEMBER_ROLE
+                ? []
+                : [{ user_id: m.user_id, role: m.role }],
+            ),
           }
         : EMPTY_VALUES,
     );

--- a/apps/frontend/src/types/project.ts
+++ b/apps/frontend/src/types/project.ts
@@ -1,6 +1,8 @@
 import {
+  ADMIN_MEMBER_ROLE,
   DEFAULT_PROJECT_ROLE,
   PROJECT_ROLES,
+  type MemberDisplayRole,
   type ProjectRole,
 } from '@branch/rbac';
 import type { Expenditure } from './expenditure';
@@ -16,13 +18,19 @@ export interface Project {
     created_at: string | null;
 };
 
-export { DEFAULT_PROJECT_ROLE, PROJECT_ROLES, type ProjectRole };
+export {
+  ADMIN_MEMBER_ROLE,
+  DEFAULT_PROJECT_ROLE,
+  PROJECT_ROLES,
+  type MemberDisplayRole,
+  type ProjectRole,
+};
 
 export interface Member {
   user_id: number;
   name: string;
   email: string;
-  role: ProjectRole;
+  role: MemberDisplayRole;
   profile_image?: string | null;
 }
 

--- a/shared/rbac/src/subject.ts
+++ b/shared/rbac/src/subject.ts
@@ -36,6 +36,10 @@ export const DEFAULT_PROJECT_ROLE: ProjectRole = 'Student';
 /** Membership roles that make someone a director of a project. */
 export const DIRECTOR_ROLES: readonly ProjectRole[] = ['Director'];
 
+export const ADMIN_MEMBER_ROLE = 'Admin';
+
+export type MemberDisplayRole = ProjectRole | typeof ADMIN_MEMBER_ROLE;
+
 export const ANONYMOUS: RbacSubject = {
   userId: null,
   isAdmin: false,


### PR DESCRIPTION
> **Not green yet — 49 backend tests fail.** Pushed at your request; see "What still needs doing" at the bottom before reviewing.

## Change

Admins already reach every project through `is_admin`, so a `project_memberships` row for one was a weaker second copy of that flag. They are now **composed into** a project's roster rather than stored in it.

- `listRoster()` returns every admin first, labelled `ADMIN_MEMBER_ROLE`, then the stored memberships with any admin among them dropped rather than listed twice. Used by both `GET /projects/{id}/overview` and `GET /projects/{id}/members`. `StaffCard` already renders `title` as `<Name>, <title>`, so "Ada Lovelace, Admin" falls out with no frontend change.
- **Not assignable, so no dropdown.** `GET /projects/assignable-staff` filters admins out (`is_admin IS NOT TRUE`, matching the codebase's strict `=== true`), so no admin ever reaches the picker and none gets a role select. `POST /projects` and `PUT /projects/{id}` reject an admin id with a 400 instead of writing a row the roster would ignore.
- `ProjectFormModal` drops admins when it seeds from the overview roster, so an edit cannot post one back.
- `PROJECT_ROLES` is unchanged — still `Director | Student`, still what the CHECK accepts. `ADMIN_MEMBER_ROLE` sits beside it as a display label only.

## No migration

You said leftover admin membership rows are fine, so there is none. The roster dedupes them, and the headcounts subtract them: `member_count` on the list card and `staff_count` on the dashboard are `rollup − storedAdmins + admins`. That is correct whether or not those rows exist, so the card and the roster below it always agree.

## Seed

Every seeded user was an admin, so an admin-filtered picker had nobody to offer and the dev UI could not assign anyone. Added three non-admin staff (Sam Okafor, Priya Raman, Diego Alvarez) and moved the seeded memberships onto them.

## Verified

- `apps/frontend`: `tsc --noEmit` clean, 38/38 suites and 367 tests pass.
- `apps/backend/lambdas/projects`: `tsc --noEmit` clean.
- `shared/rbac` builds.

## What still needs doing

`apps/backend/lambdas/projects` — **4 suites, 49 tests failing.** I ran them but had not diagnosed them before pushing. Known causes from the change itself:

- `project-page.unit.test.ts` — assigns admin ids 1/2/3, which now 400. Needs the new non-admin ids 4/5/6. Also `expect(staff.length).toBeGreaterThan(0)` on `assignable-staff`, and member-count assertions that now include the admins.
- `projects.e2e.test.ts` — hardcodes user ids created after the seed; the three new seed users shift them. Plus `staff_count` assertions.
- `rollups.e2e.test.ts` — its shared invariant compares `project_rollup.member_count` against `COUNT(*)` on the table. My change does not touch the rollup, so this one I have not explained yet and it needs looking at first.
- `dashboard.unit.test.ts` — mocked rows with fixed `staff_count`.

Also not done: no test yet covering admin-first ordering, the 400 on assigning an admin, or the "Name, Admin" rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)